### PR TITLE
Fix org switcher menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.0.2] - 2020-11-09
+- Fix org switcher menu items.
+
 ## [1.0.1] - 2020-10-28
 - Replace empty channels copy in Org Switcher.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix org switcher menu items.
 
 ## [1.0.1] - 2020-10-28
-- Replace empty channels copy in Org Switcher.
+- Replace empty channels copy in org switcher.
 
 ## [1.0.0] - 2020-10-21
 - First release. 🎉

--- a/src/NavBar/index.jsx
+++ b/src/NavBar/index.jsx
@@ -197,7 +197,7 @@ export function appendOrgSwitcher(orgSwitcher) {
       itemCopy.defaultTooltipMessage = 'No channels connected yet.';
     }
 
-    return item;
+    return itemCopy;
   });
 }
 


### PR DESCRIPTION
Fix code regression caused when transferring the app-shell from the ui to its own package.
Menu items are missing some information: channels icons, empty state message
<img width="400" alt="Screenshot 2020-11-02 at 10 35 53" src="https://user-images.githubusercontent.com/16758464/98547183-b1960a00-228f-11eb-8877-06f6f98da68d.png">
