### PR TITLE
Allow hiding of tooltip message within the org switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [1.0.4] - 2020-11-18
+- Allow tooltip message for org switcher to be hidden.
+
 ## [1.0.3] - 2020-11-10
 - Refactor appendOrgSwitcher function.
 

--- a/src/NavBar/index.jsx
+++ b/src/NavBar/index.jsx
@@ -194,7 +194,9 @@ export function appendOrgSwitcher(orgSwitcher) {
       hasDivider: index === 0 && !!orgSwitcher.title,
       dividerTitle: index === 0 && orgSwitcher.title,
       subItems: subItems.length ? subItems : undefined,
-      defaultTooltipMessage: !subItems.length && 'No channels connected yet.',
+      defaultTooltipMessage: orgSwitcher.hideTooltips
+        ? ''
+        : !subItems.length && 'No channels connected yet.',
     };
   });
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Allows the org switcher to include a `hideTooltips` property in order to hide tool tips (channels info) when a user hovers over that organization in the org switcher. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The org switcher provides a list of channels associated with an organization when a user hovers over that organization. If no channels have been connected yet, then it defaults to a tooltip message that reads, `No channels connected yet.`. For the global org switcher, we do not yet have shared channels in place so we need a way to hide these tooltips for now. 

## Screenshots (if appropriate):

**Before:**

![Screen Recording 2020-11-18 at 07 42 AM](https://user-images.githubusercontent.com/10112294/99532078-bc2c5f80-2971-11eb-9ed8-2e34cc8c6f27.gif)


**After:**
![Screen Recording 2020-11-18 at 07 22 AM](https://user-images.githubusercontent.com/10112294/99531882-68ba1180-2971-11eb-8387-bbc6641ae39e.gif)
