### PR TITLE
Remove requirement for 'engageRollOut' feature flip

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,27 @@ import {
   ContentWrapper,
 } from './style';
 
-const ENABLE_ENGAGE_URL = 'https://login.buffer.com/signup?product=engage';
+const ENGAGE_SIGNUP_URL = 'https://login.buffer.com/signup?product=engage';
+
+const getProductURL = product => `https://${product}.buffer.com`;
+
+const getProductList = enabledProducts => [
+  {
+    id: 'publish',
+    isNew: false,
+    href: getProductURL('publish')
+  },
+  {
+    id: 'analyze',
+    isNew: false,
+    href: getProductURL('analyze')
+  },
+  {
+    id: 'engage',
+    isNew: true,
+    href: enabledProducts.includes('engage') ? getProductURL('engage') : ENGAGE_SIGNUP_URL
+  }
+];
 
 /**
  * The AppShell component is a general purpose wrapper for all of our applications. At the moment it's primarily a wrapper for the `NavBar` component. Check out the example below to see how to integrate it into your app.
@@ -30,54 +50,26 @@ const AppShell = ({
   displaySkipLink,
   orgSwitcher,
   isImpersonation,
-}) => {
-  const engageEnabled = enabledProducts.includes('engage');
-  const engageAccess = featureFlips.includes('engageRollOut');
-
-  let products = ['publish', 'analyze'];
-  if (engageEnabled || engageAccess) {
-    products.push('engage');
-  }
-
-  products = products.map((product) => {
-    const productURL = `https://${product}.buffer.com`;
-
-    if (product === 'engage') {
-      return {
-        id: product,
-        isNew: true,
-        href: engageEnabled ? productURL : ENABLE_ENGAGE_URL,
-      };
-    }
-
-    return {
-      id: product,
-      isNew: false,
-      href: productURL,
-    };
-  });
-
-  return (
-    <AppShellStyled>
-      {/* <GlobalStyles /> */}
-      <NavBar
-        products={products}
-        activeProduct={activeProduct}
-        user={user}
-        helpMenuItems={helpMenuItems}
-        onLogout={onLogout}
-        displaySkipLink={displaySkipLink}
-        orgSwitcher={orgSwitcher}
-        isImpersonation={isImpersonation}
-      />
-      {bannerOptions && <Banner {...bannerOptions} />}
-      <Wrapper>
-        {sidebar && <SidebarWrapper>{sidebar}</SidebarWrapper>}
-        <ContentWrapper>{content}</ContentWrapper>
-      </Wrapper>
-    </AppShellStyled>
-  );
-};
+}) => (
+  <AppShellStyled>
+    {/* <GlobalStyles /> */}
+    <NavBar
+      products={getProductList(enabledProducts)}
+      activeProduct={activeProduct}
+      user={user}
+      helpMenuItems={helpMenuItems}
+      onLogout={onLogout}
+      displaySkipLink={displaySkipLink}
+      orgSwitcher={orgSwitcher}
+      isImpersonation={isImpersonation}
+    />
+    {bannerOptions && <Banner {...bannerOptions} />}
+    <Wrapper>
+      {sidebar && <SidebarWrapper>{sidebar}</SidebarWrapper>}
+      <ContentWrapper>{content}</ContentWrapper>
+    </Wrapper>
+  </AppShellStyled>
+);
 
 AppShell.propTypes = {
   /** The list of features enabled for the user */


### PR DESCRIPTION
## Overview

This PR has the changes for:
- Removing the requirement for the `engageRollOut` feature flip in order to display the `Engage` link on the navigation bar.
- Change the display of `Publish`, `Analyze` and `Engage` to `Publishing`, `Analytics` and `Engagement` -> For more context you can check [here](https://threads.com/34391716122).