### PR TITLE
Update 'Engagement' URL

### DIFF
--- a/src/NavBar/NavBarProducts/NavBarProducts.jsx
+++ b/src/NavBar/NavBarProducts/NavBarProducts.jsx
@@ -142,10 +142,10 @@ const getLogo = (product) => {
 
 const NavBarProducts = ({ products, activeProduct }) => (
   <StyledNavBarProducts>
-    {products.map(({ id, label, href, isNew }) => (
+    {products.map(({ id, label, isNew }) => (
       <ProductLink
         active={activeProduct === id}
-        href={href}
+        href={`https://${id}.buffer.com`}
         key={id}
         id={`product-${id}`}
       >

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,28 +12,21 @@ import {
   ContentWrapper,
 } from './style';
 
-const ENGAGE_SIGNUP_URL = 'https://login.buffer.com/signup?product=engage';
-
-const getProductURL = product => `https://${product}.buffer.com`;
-
-const getProductList = enabledProducts => [
+const products = [
   {
     id: 'publish',
     label: 'Publishing',
-    isNew: false,
-    href: getProductURL('publish')
+    isNew: false
   },
   {
     id: 'analyze',
     label: 'Analytics',
-    isNew: false,
-    href: getProductURL('analyze')
+    isNew: false
   },
   {
     id: 'engage',
     label: 'Engagement',
-    isNew: true,
-    href: enabledProducts.includes('engage') ? getProductURL('engage') : ENGAGE_SIGNUP_URL
+    isNew: true
   }
 ];
 
@@ -42,7 +35,6 @@ const getProductList = enabledProducts => [
  */
 const AppShell = ({
   featureFlips,
-  enabledProducts,
   activeProduct,
   user,
   helpMenuItems,
@@ -57,7 +49,7 @@ const AppShell = ({
   <AppShellStyled>
     {/* <GlobalStyles /> */}
     <NavBar
-      products={getProductList(enabledProducts)}
+      products={products}
       activeProduct={activeProduct}
       user={user}
       helpMenuItems={helpMenuItems}
@@ -77,9 +69,6 @@ const AppShell = ({
 AppShell.propTypes = {
   /** The list of features enabled for the user */
   featureFlips: PropTypes.arrayOf(PropTypes.string),
-
-  /** The list of products that the user has enabled on their account. */
-  enabledProducts: PropTypes.arrayOf(PropTypes.string),
 
   /** The currently active (highlighted) product in the `NavBar`. */
   activeProduct: PropTypes.oneOf(['publish', 'analyze', 'engage']),
@@ -155,7 +144,6 @@ AppShell.propTypes = {
 AppShell.defaultProps = {
   featureFlips: [],
   sidebar: null,
-  enabledProducts: [],
   activeProduct: undefined,
   bannerOptions: null,
   onLogout: undefined,


### PR DESCRIPTION
## Overview

This PR has the changes needed to always make the `Engagement` link point to `https://engage.buffer.com`, removing the decision of redirecting the user to the signup page if needed. 

Initially users without an `engage` product link would be redirected so they can perform a signup first but, we have an extra step now, based on the `canAccessEngagement` value so users under a free plan are redirected to `https://engage.buffer.com/free-plan`. Ideally this kind of decisions should be made on the App Shell to avoid extra redirects but that's not easy for now. We will make that improvement once the smart App Shell is ready 🙂 