### PR TITLE
Get access flags for the organizations the account belongs to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.0] - 2021-02-04
+- Add canAccess* flags to the organizations an account belongs to:
+  - `canAccessAnalytics`
+  - `canAccessEngagement`
+  - `canAccessPublishing`
+
 ## [2.0.0] - 2021-02-04
 - Add global organization switcher
 - Breaking change: Added dependency with Apollo: now the AppShell needs to be 

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -10,10 +10,13 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production babel src --out-dir lib",
     "prettier": "prettier --write ./src",
-    "publish": "npm publish --access public",
+    "prepublish": "npm build",
     "watch": "cross-env NODE_ENV=production babel src --out-dir lib --watch",
     "test": "jest",
     "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [],
   "browserslist": [

--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -19,6 +19,11 @@ export const QUERY_ACCOUNT = gql`
         canEdit
         role
         createdAt
+        billing {
+          canAccessAnalytics
+          canAccessEngagement
+          canAccessPublishing
+        }
       }
       organizations {
         id

--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -28,6 +28,11 @@ export const QUERY_ACCOUNT = gql`
       organizations {
         id
         name
+        billing {
+          canAccessAnalytics
+          canAccessEngagement
+          canAccessPublishing
+        }
       }
       products {
         name


### PR DESCRIPTION
## Purpose

To add canAccess* flags to the organizations an account belongs to:

- `canAccessAnalytics`
- `canAccessEngagement`
- `canAccessPublishing`