### PR TITLE
Add missing account query fields

### DIFF
--- a/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
@@ -25,7 +25,7 @@ const UpgradeCTA = () => {
       {({ currentOrganization }) => {
         if (currentOrganization.billing) {
           const { subscription, canStartTrial } = currentOrganization.billing
-          const isFree = subscription.plan.id === 'free'
+          const isFree = subscription?.plan.id === 'free'
 
           return (<ModalContext.Consumer>{({ openModal }) => (<>
             {isFree && <Cta>

--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -31,7 +31,6 @@ export const QUERY_ACCOUNT = gql`
             billingRedirectUrl
           }
           ... on OBBilling {
-            canAccessAnalytics
             canStartTrial
             subscription {
               trial {
@@ -76,6 +75,45 @@ export const QUERY_ACCOUNT = gql`
           canAccessAnalytics
           canAccessEngagement
           canAccessPublishing
+          paymentDetails {
+            hasPaymentDetails
+          }
+          ... on MPBilling {
+            billingRedirectUrl
+          }
+          ... on OBBilling {
+            canStartTrial
+            subscription {
+              trial {
+                isActive
+                remainingDays
+              }
+              plan {
+                id
+              }
+            }
+            changePlanOptions {
+              planId
+              planName
+              planInterval
+              channelsQuantity
+              description
+              isCurrentPlan
+              highlights
+              currency
+              basePrice
+              totalPrice
+              discountPercentage
+              discountNote
+              priceNote
+              summary {
+                details
+                intervalBasePrice
+                intervalUnit
+              }
+              isRecommended
+            }
+          }
         }
       }
       products {


### PR DESCRIPTION
**What**
Add missing account query fields: since we update the cache manually when we select an org, the organizations object has to return the same fields as the currentOrganization one.

This is just a temporary fix, we're fixing the mutation (as mentioned in the [Apollo Mutation thread](https://threads.com/34393830700))