### PR TITLE
Change 400 error redirect to 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+
+## [2.6.3] - 2021-03-25
+- Change account redirect error from 400 to 401
 ## [2.6.2] - 2021-03-25
 - Add missing field in account query
 ## [2.6.0] - 2021-03-24

--- a/packages/app-shell/src/index.jsx
+++ b/packages/app-shell/src/index.jsx
@@ -53,7 +53,7 @@ const AppShell = ({
     ...data.account,
   };
 
-  if (error?.networkError?.statusCode === 400) {
+  if (error?.networkError?.statusCode === 401) {
     window.location.assign(getLogoutUrl(window.location.href));
   }
 


### PR DESCRIPTION
401 error makes more sense for unauthorized, so I'll reach out to Core around whether we can get this changed. 