### PR TITLE
set upgrade intent in navbar CTA

### DIFF
--- a/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
@@ -40,7 +40,7 @@ const UpgradeCTA = () => {
                             ? openModal(MODALS.startTrial, {
                                 cta: 'Start a 14-day free trial',
                               })
-                            : openModal(MODALS.planSelector, { cta: 'Ugrade' });
+                            : openModal(MODALS.planSelector, { cta: 'Ugrade', isUpgradeIntent: true });
                         }}
                         icon={<FlashIcon />}
                         label={


### PR DESCRIPTION
forgot to add this is my last PR but that upgrade CTA will always be with the intent to upgrade 😅 