### PR TITLE
[Fix] Check if previous data is defined when updating cache after org

### DIFF
--- a/packages/app-shell/src/hooks/useOrgSwitcher.js
+++ b/packages/app-shell/src/hooks/useOrgSwitcher.js
@@ -11,7 +11,7 @@ function useOrgSwitcher() {
     )[0];
     const updatedData = {
       account: {
-        ...previousData.account,
+        ...previousData?.account,
         currentOrganization: organizationSelected,
       },
     };


### PR DESCRIPTION
### Description

There seems to be an error related to updating the cache with `previousData` when a user selects a new org in the org switcher ([Slack thread for context](https://buffer.slack.com/archives/C01K9FWJVBJ/p1617122335356700)):

![e257993087e76d578c2237d5195595b1](https://user-images.githubusercontent.com/10112294/113050400-cad22100-9172-11eb-9126-a215f447030b.png)


@anafilipadealmeida @msanroman I am unfamiliar with updating the cache, so please let me know if this can be better handled (for example, if we should expect `previousData` to always be defined). 


### Screenshots

**Before:**

https://user-images.githubusercontent.com/10112294/113049861-23ed8500-9172-11eb-92c7-95321a52c9af.mp4



**After:**

https://user-images.githubusercontent.com/10112294/113049873-27810c00-9172-11eb-9191-edd3f9014655.mp4


