### PR TITLE
Extract the product name from the url for tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const ModalTesting = () => (
   <ModalContext.Consumer>
     {modal => (
       <button onClick={
-        () => {modal.openModal(MODALS.paymentMethod, { cta: 'Render Modal', isUpgradeIntent: false })}
+        () => {modal.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'renderModal' isUpgradeIntent: false })}
       }>Render Modal</button>
     )}
   </ModalContext.Consumer>
@@ -55,7 +55,7 @@ In the method above, you'll notice that openModal accepts an object as a second 
 Some places in our apps, the user's intent is to upgrade from Trial or from Free. For that, we only want to show 2 plan options (Individual and Team) instead of 3. For these CTAs, pass in `isUpgradeIntent : true` as part of the second paramater in openModal:
 ```
 <button onClick={
-    () => {modal.openModal(MODALS.paymentMethod, { cta: 'Upgrade', isUpgradeIntent: true })}
+    () => {modal.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'upgradePlan', isUpgradeIntent: true })}
   }>
   Upgrade
 </button>

--- a/packages/app-shell/src/Confirmation/index.jsx
+++ b/packages/app-shell/src/Confirmation/index.jsx
@@ -62,11 +62,10 @@ const Screen = ({
     const cta = data && data.cta ? data.cta : null;
     useTrackPageViewed({
       payload: {
-        name: 'Confirmation',
-        title: 'Plan selector',
+        name: 'confirmation',
+        title: 'planSelector',
         cta,
         ctaButton: cta,
-        ctaView: data && data.ctaView ? data.ctaView : null,
       },
       user: currentUser,
     });

--- a/packages/app-shell/src/Modal/index.jsx
+++ b/packages/app-shell/src/Modal/index.jsx
@@ -9,17 +9,17 @@ import Confirmation from '../Confirmation';
 const ModalContent = ({ modal }) => {
   switch (modal) {
     case MODALS.paymentMethod:
-      return (<PaymentMethod />);
+      return <PaymentMethod />;
     case MODALS.planSelector:
-      return (<PlanSelector />);
+      return <PlanSelector />;
     case MODALS.success:
-      return (<Confirmation />);
+      return <Confirmation />;
     case MODALS.startTrial:
-      return (<StartTrial />);
+      return <StartTrial />;
     default:
       return null;
   }
-}
+};
 
 const Modal = ({ modal, openModal, isAwaitingUserAction }) => {
   const [hasModal, setHasModal] = useState(!!modal);
@@ -27,7 +27,7 @@ const Modal = ({ modal, openModal, isAwaitingUserAction }) => {
   useEffect(() => {
     if (isAwaitingUserAction) {
       openModal(MODALS.planSelector, {
-        cta: 'Render Modal',
+        cta: 'awaitingUserAction',
         isUpgradeIntent: false,
       });
     }
@@ -37,13 +37,19 @@ const Modal = ({ modal, openModal, isAwaitingUserAction }) => {
     setHasModal(!!modal);
   }, [modal]);
 
-  return (<>
-    {hasModal && <SimpleModal closeAction={() => {
-      openModal(null);
-    }}>
-      <ModalContent modal={modal} />
-    </SimpleModal>}
-  </>)
-}
+  return (
+    <>
+      {hasModal && (
+        <SimpleModal
+          closeAction={() => {
+            openModal(null);
+          }}
+        >
+          <ModalContent modal={modal} />
+        </SimpleModal>
+      )}
+    </>
+  );
+};
 
 export default Modal;

--- a/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
@@ -38,9 +38,14 @@ const UpgradeCTA = () => {
                         onClick={() => {
                           canStartTrial
                             ? openModal(MODALS.startTrial, {
-                                cta: 'Start a 14-day free trial',
+                                cta: 'startFreeTrial',
+                                ctaButton: 'startFreeTrial',
                               })
-                            : openModal(MODALS.planSelector, { cta: 'Ugrade', isUpgradeIntent: true });
+                            : openModal(MODALS.planSelector, {
+                                cta: 'ugradePlan',
+                                ctaButton: 'ugradePlan',
+                                isUpgradeIntent: true,
+                              });
                         }}
                         icon={<FlashIcon />}
                         label={

--- a/packages/app-shell/src/PaymentMethod/index.jsx
+++ b/packages/app-shell/src/PaymentMethod/index.jsx
@@ -15,8 +15,8 @@ const PaymentMethod = () => {
     const cta = data && data.cta ? data.cta : null;
     useTrackPageViewed({
       payload: {
-        name: 'Payment method',
-        title: 'Plan selector',
+        name: 'addPaymentDetails',
+        title: 'planSelector',
         cta,
         ctaButton: cta,
         ctaView: data && data.ctaView ? data.ctaView : null,
@@ -34,12 +34,17 @@ const PaymentMethod = () => {
               <StripeProvider>
                 <Form
                   openPlans={(isUpgradeIntent) => {
-                    openModal(MODALS.planSelector, { isUpgradeIntent });
+                    openModal(MODALS.planSelector, {
+                      isUpgradeIntent,
+                      cta: 'planSelection',
+                      ctaButton: 'goBackToPlanSelection',
+                      ctaView: modal,
+                    });
                   }}
                   openSuccess={(newData) => {
                     openModal(MODALS.success, {
                       ...newData,
-                      cta: 'Confirm Payment',
+                      cta: 'addPaymentDetails',
                       ctaView: modal,
                     });
                   }}

--- a/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
@@ -12,6 +12,7 @@ import useUpdateSubscriptionPlan from '../hooks/useUpdateSubscriptionPlan';
 import {
   useTrackPlanSelectorViewed,
   useTrackPageViewed,
+  formatCTAString,
 } from '../../hooks/useSegmentTracking';
 import {
   ButtonContainer,
@@ -63,7 +64,7 @@ export const PlanSelectorContainer = ({
     error,
     processing,
   } = useUpdateSubscriptionPlan({ user, selectedPlan });
-  const { label, action, updateButton } = useButtonOptions({
+  const { label, action, updateButton, ctaButton } = useButtonOptions({
     selectedPlan,
     updatePlan,
     openPaymentMethod,
@@ -81,20 +82,22 @@ export const PlanSelectorContainer = ({
     const cta = modalData && modalData.cta ? modalData.cta : null;
     useTrackPlanSelectorViewed({
       payload: {
-        currentPlan: `${selectedPlan.planId}_${selectedPlan.planInterval}`,
+        currentPlan: formatCTAString(
+          `${selectedPlan.planId} ${selectedPlan.planInterval}`
+        ),
         screenName: headerLabel,
         cta,
-        ctaButton: cta,
+        ctaButton: ctaButton,
       },
       user,
     });
 
     useTrackPageViewed({
       payload: {
-        name: 'Plan selection',
-        title: 'Plan selector',
+        name: 'planSelection',
+        title: 'planSelector',
         cta,
-        ctaButton: cta,
+        ctaButton: ctaButton,
       },
       user,
     });

--- a/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.js
+++ b/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatCTAString } from '../../hooks/useSegmentTracking'
 
 const useButtonOptions = ({
   selectedPlan,
@@ -50,6 +51,7 @@ const useButtonOptions = ({
     label,
     action,
     updateButton,
+    ctaButton: formatCTAString(label)
   };
 };
 

--- a/packages/app-shell/src/StartTrial/index.jsx
+++ b/packages/app-shell/src/StartTrial/index.jsx
@@ -5,94 +5,122 @@ import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
 
-import { Error } from '../PaymentMethod/style'
+import { Error } from '../PaymentMethod/style';
 import { MODALS } from '../hooks/useModal';
 import { UserContext } from '../context/User';
 import { ModalContext } from '../context/Modal';
 import { START_TRIAL } from '../graphql/billing';
-import { QUERY_ACCOUNT } from '../graphql/account'
+import { QUERY_ACCOUNT } from '../graphql/account';
 
-import {
-  Holder,
-  Content,
-  Ctas,
-} from './style'
+import { Holder, Content, Ctas } from './style';
 
-const StartTrial = ({ user, openModal}) => {
-  const [suggestedPlan, setSuggestedPlan] = useState(null)
-  const [processing, setProcessing] = useState(false)
+const StartTrial = ({ user, openModal }) => {
+  const [suggestedPlan, setSuggestedPlan] = useState(null);
+  const [processing, setProcessing] = useState(false);
   useEffect(() => {
     if (user) {
-      let plan = user.currentOrganization.billing.changePlanOptions.find(p => p.isRecommended)
+      let plan = user.currentOrganization.billing.changePlanOptions.find(
+        (p) => p.isRecommended
+      );
       if (!plan) {
         plan = {
           planId: 'team',
-          planInterval: "month",
-        }
+          planInterval: 'month',
+        };
       }
-      setSuggestedPlan(plan)
+      setSuggestedPlan(plan);
     }
-  }, [user])
+  }, [user]);
 
-  const [startTrial, { data:trial, error }] = useMutation(
-    START_TRIAL,
-    {
-      refetchQueries: [{ query: QUERY_ACCOUNT }],
-    }
-  );
+  const [startTrial, { data: trial, error }] = useMutation(START_TRIAL, {
+    refetchQueries: [{ query: QUERY_ACCOUNT }],
+  });
 
   useEffect(() => {
     if (trial) {
-      openModal(MODALS.success, { startedTrial: true })
+      openModal(MODALS.success, { startedTrial: true });
     }
-  }, [trial])
+  }, [trial]);
 
-  return(<Holder>
-    <Content>
-      <Text type="h1">Want to try our trial?</Text>
-      <Text type="p">Get the best we have to offer to see how it fits for you and your business.</Text>
-      <ol>
-        <li> <CheckmarkIcon size="medium" /><Text>Unlimited users</Text></li>
-        <li> <CheckmarkIcon size="medium" /><Text>Unlimited channels</Text></li>
-        <li> <CheckmarkIcon size="medium" /><Text>No credit card required</Text></li>
-      </ol>
-      <Ctas>
-        <Button
-          type="primary"
-          disabled={!suggestedPlan || processing}
-          onClick={() => {
-            setProcessing(true)
-            startTrial({
-              variables: {
-                organizationId: user.currentOrganization.id,
-                plan: suggestedPlan.planId,
-                interval: suggestedPlan.planInterval,
-              },
-            }).catch((e) => {
-              setProcessing(false)
-              console.error(e)
-            });
-          }}
-          label={processing ? "Processing ..." : "Start Free 14-day Trial"}
+  return (
+    <Holder>
+      <Content>
+        <Text type="h1">Want to try our trial?</Text>
+        <Text type="p">
+          Get the best we have to offer to see how it fits for you and your
+          business.
+        </Text>
+        <ol>
+          <li>
+            {' '}
+            <CheckmarkIcon size="medium" />
+            <Text>Unlimited users</Text>
+          </li>
+          <li>
+            {' '}
+            <CheckmarkIcon size="medium" />
+            <Text>Unlimited channels</Text>
+          </li>
+          <li>
+            {' '}
+            <CheckmarkIcon size="medium" />
+            <Text>No credit card required</Text>
+          </li>
+        </ol>
+        <Ctas>
+          <Button
+            type="primary"
+            disabled={!suggestedPlan || processing}
+            onClick={() => {
+              setProcessing(true);
+              startTrial({
+                variables: {
+                  organizationId: user.currentOrganization.id,
+                  plan: suggestedPlan.planId,
+                  interval: suggestedPlan.planInterval,
+                },
+              }).catch((e) => {
+                setProcessing(false);
+                console.error(e);
+              });
+            }}
+            label={processing ? 'Processing ...' : 'Start Free 14-day Trial'}
+          />
+          <Button
+            type="secondary"
+            onClick={() => {
+              openModal(MODALS.planSelector, {
+                cta: 'planSelection',
+                ctaButton: 'checkOutPaidPlans',
+              });
+            }}
+            label="Check Out Paid Plans"
+          />
+        </Ctas>
+        <Error
+          error={
+            error
+              ? {
+                  message: "We can't start your trial, please contact support.",
+                }
+              : null
+          }
         />
-        <Button
-          type="secondary"
-          onClick={() => {openModal(MODALS.planSelector)}}
-          label="Check Out Paid Plans"
-        />
-      </Ctas>
-      <Error error={error ? { message: "We can't start your trial, please contact support." } : null} />
-    </Content>
-  </Holder>)
-}
+      </Content>
+    </Holder>
+  );
+};
 
 const StartTrialProvider = () => {
-  return (<UserContext.Consumer>
-    {user => (<ModalContext.Consumer>{
-      ({ openModal }) => (
-        <StartTrial user={user} openModal={openModal} />
-      )}</ModalContext.Consumer>)}
-  </UserContext.Consumer>)
-}
+  return (
+    <UserContext.Consumer>
+      {(user) => (
+        <ModalContext.Consumer>
+          {({ openModal }) => <StartTrial user={user} openModal={openModal} />}
+        </ModalContext.Consumer>
+      )}
+    </UserContext.Consumer>
+  );
+};
 
-export default StartTrialProvider
+export default StartTrialProvider;

--- a/packages/app-shell/src/hooks/useSegmentTracking.js
+++ b/packages/app-shell/src/hooks/useSegmentTracking.js
@@ -1,5 +1,10 @@
 import { getProductPath } from '../NavBar';
 
+export const formatCTAString = (str) => {
+  const result = str.split(/\s+/).map(word => `${word.charAt(0).toUpperCase()}${word.slice(1)}`).join('');
+  return `${result.charAt(0).toLowerCase()}${result.slice(1)}`;
+}
+
 /**
  *
  */
@@ -13,21 +18,22 @@ export const useTrackPlanSelectorViewed = ({ payload, user }) => {
     return;
   }
 
+  
 
   const baseUrl = window.location.origin;
+  const product = getProductPath(baseUrl);
   const eventData = {
     organizationId: organization.id,
-    ctaApp: getProductPath(baseUrl),
-    ctaVersion: 1,
+    ctaApp: product,
+    ctaVersion: '1',
     currentPlan: null,
-    ctaLocation: 'app-shell',
+    ctaLocation: 'appShell',
     screenName: null, // Human readable name of the section of the plan selector viewed (e.g., ""plans"", ""billing_info"", etc.)
-    cta: null, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
     ctaButton: null, // What is the name or action of the CTA?  In many cases it makes sense to describe the intended result of the CTA, like `proTrial` or `publishPro`,
-
     ctaView: null, // What website page or app view is the CTA located?  Examples would be, `composer` or `analyticsOverview` for Publish, and `pricingPublish` for the Publish pricing page on the Buffer marketing site
     
     ...payload,
+    cta: `${product}-${payload.cta}-planSelectorViewed`, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
   };
 
   window.analytics && window.analytics.track('Plan Selector Viewed', eventData);
@@ -48,16 +54,16 @@ export const useTrackPageViewed = ({ payload, user }) => {
   const eventData = {
     organizationId: organization.id,
     ctaApp: product,
-    ctaVersion: 1,
+    ctaVersion: '1',
     product,
     url: window.location.href || null,
     search: window.location.search || null,
     path: window.location.pathname || null, // The path typically refers to a file or directory on the web server.
-    ctaLocation: 'app-shell',
+    ctaLocation: 'appShell',
     title: null,
     name: null, // Human readable name of the page (e.g., ""overview"", ""posts"", etc.)
-    cta: null, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
     ctaButton: null, // What is the name or action of the CTA?  In many cases it makes sense to describe the intended result of the CTA, like `proTrial` or `publishPro`
+    ctaView: null, // What website page or app view is the CTA located?  Examples would be, `composer` or `analyticsOverview` for Publish, and `pricingPublish` for the Publish pricing page on the Buffer marketing site
 
     channel: null, // Channel of the page, if applicable (e.g., ""facebook"", ""instagram"", etc.)
     channelId: null, // The database id for the channel document
@@ -65,9 +71,9 @@ export const useTrackPageViewed = ({ payload, user }) => {
     channelType: null, // What is the type of channel? ex. "page", "group"
     platform: null, // The platform on which the page view occurred (e.g. ""classic"", ""new_publish"", ""marketing"", ""ios"")
     referrer: null, // The address of the webpage which is linked to the resource being requested. By checking the referrer, the new webpage can see where the request originated.
-    ctaView: null, // What website page or app view is the CTA located?  Examples would be, `composer` or `analyticsOverview` for Publish, and `pricingPublish` for the Publish pricing page on the Buffer marketing site
     
     ...payload,
+    cta: `${product}-${payload.cta}-planSelector`, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
   };
 
   window.analytics && window.analytics.track('Page Viewed', eventData);

--- a/packages/app-shell/src/hooks/useSegmentTracking.js
+++ b/packages/app-shell/src/hooks/useSegmentTracking.js
@@ -1,3 +1,5 @@
+import { getProductPath } from '../NavBar';
+
 /**
  *
  */
@@ -11,9 +13,11 @@ export const useTrackPlanSelectorViewed = ({ payload, user }) => {
     return;
   }
 
+
+  const baseUrl = window.location.origin;
   const eventData = {
     organizationId: organization.id,
-    ctaApp: window.PRODUCT_TRACKING_KEY || null,
+    ctaApp: getProductPath(baseUrl),
     ctaVersion: 1,
     currentPlan: null,
     ctaLocation: 'app-shell',
@@ -39,11 +43,13 @@ export const useTrackPageViewed = ({ payload, user }) => {
     return;
   }
 
+  const baseUrl = window.location.origin;
+  const product = getProductPath(baseUrl);
   const eventData = {
     organizationId: organization.id,
-    ctaApp: window.PRODUCT_TRACKING_KEY || null,
+    ctaApp: product,
     ctaVersion: 1,
-    product: window.PRODUCT_TRACKING_KEY || null,
+    product,
     url: window.location.href || null,
     search: window.location.search || null,
     path: window.location.pathname || null, // The path typically refers to a file or directory on the web server.

--- a/packages/app-shell/src/hooks/useSegmentTracking.test.js
+++ b/packages/app-shell/src/hooks/useSegmentTracking.test.js
@@ -44,8 +44,9 @@ describe('useSegmentTracking hooks', () => {
       window.location.origin = 'https://analyze.buffer.com';
       useTrackPlanSelectorViewed({
         payload: {
-          screenName: 'Change My Plan',
-          currentPlan: 'individual_month',
+          screenName: 'changeMyPlan',
+          currentPlan: 'individualMonth',
+          cta: 'upgradePlan',
         },
         user: {
           isImpersonation: false,
@@ -60,11 +61,11 @@ describe('useSegmentTracking hooks', () => {
         {
           organizationId: '123-test-org',
           ctaApp: 'analyze',
-          ctaVersion: 1,
-          currentPlan: 'individual_month',
-          screenName: 'Change My Plan',
-          ctaLocation: 'app-shell',
-          cta: null,
+          ctaVersion: '1',
+          currentPlan: 'individualMonth',
+          screenName: 'changeMyPlan',
+          ctaLocation: 'appShell',
+          cta: 'analyze-upgradePlan-planSelectorViewed',
           ctaView: null,
           ctaButton: null,
         }
@@ -105,8 +106,9 @@ describe('useSegmentTracking hooks', () => {
 
       useTrackPageViewed({
         payload: {
-          name: 'The Page',
-          title: 'Page title',
+          name: 'thePage',
+          title: 'pageTitle',
+          cta: 'addPaymentMethod'
         },
         user: {
           isImpersonation: false,
@@ -121,15 +123,15 @@ describe('useSegmentTracking hooks', () => {
         {
           organizationId: '123-test-org',
           ctaApp: 'account',
-          ctaVersion: 1,
-          name: 'The Page',
-          title: 'Page title',
-          ctaLocation: 'app-shell',
+          ctaVersion: '1',
+          name: 'thePage',
+          title: 'pageTitle',
+          ctaLocation: 'appShell',
           product: 'account',
           url: 'http://localhost/the-path?query=the-query',
           path: '/the-path',
           search: '?query=the-query',
-          cta: null,
+          cta: 'account-addPaymentMethod-planSelector',
           ctaView: null,
           ctaButton: null,
           channel: null,

--- a/packages/app-shell/src/hooks/useSegmentTracking.test.js
+++ b/packages/app-shell/src/hooks/useSegmentTracking.test.js
@@ -1,6 +1,20 @@
 import { useTrackPageViewed, useTrackPlanSelectorViewed } from './useSegmentTracking';
 
 describe('useSegmentTracking hooks', () => {
+  const oldWindowLocation = window.location;
+    
+  beforeAll(() => {
+    delete window.location;
+    window.location = {
+        href: '',
+        origin: ''
+    };
+  });
+
+  afterAll(() => {
+    window.location = oldWindowLocation;
+  });
+
   describe('useTrackPlanSelectorViewed', () => {
     it('should return undefined on impersonation', () => {
       const result = useTrackPlanSelectorViewed({
@@ -23,10 +37,11 @@ describe('useSegmentTracking hooks', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should track the plan selector viewed event without PRODUCT_TRACKING_KEY', () => {
+    it('should track the plan selector viewed event', () => {
       window.analytics = {
         track: jest.fn(),
       };
+      window.location.origin = 'https://analyze.buffer.com';
       useTrackPlanSelectorViewed({
         payload: {
           screenName: 'Change My Plan',
@@ -44,41 +59,7 @@ describe('useSegmentTracking hooks', () => {
         'Plan Selector Viewed',
         {
           organizationId: '123-test-org',
-          ctaApp: null,
-          ctaVersion: 1,
-          currentPlan: 'individual_month',
-          screenName: 'Change My Plan',
-          ctaLocation: 'app-shell',
-          cta: null,
-          ctaView: null,
-          ctaButton: null,
-        }
-      );
-    });
-
-    it('should track the plan selector viewed event with PRODUCT_TRACKING_KEY', () => {
-      window.analytics = {
-        track: jest.fn(),
-      };
-      window.PRODUCT_TRACKING_KEY = 'account';
-      useTrackPlanSelectorViewed({
-        payload: {
-          screenName: 'Change My Plan',
-          currentPlan: 'individual_month',
-        },
-        user: {
-          isImpersonation: false,
-          currentOrganization: {
-            id: '123-test-org',
-          },
-        },
-      });
-
-      expect(window.analytics.track).toHaveBeenCalledWith(
-        'Plan Selector Viewed',
-        {
-          organizationId: '123-test-org',
-          ctaApp: 'account',
+          ctaApp: 'analyze',
           ctaVersion: 1,
           currentPlan: 'individual_month',
           screenName: 'Change My Plan',
@@ -92,19 +73,6 @@ describe('useSegmentTracking hooks', () => {
   });
 
   describe('useTrackPageViewed', () => {
-    const oldWindowLocation = window.location;
-    
-    beforeAll(() => {
-      delete window.location;
-      window.location = {
-          href: '',
-      };
-    });
-
-    afterAll(() => {
-      window.location = oldWindowLocation;
-    });
-
     it('should return undefined on impersonation', () => {
       const result = useTrackPageViewed({
         payload: {},
@@ -130,10 +98,10 @@ describe('useSegmentTracking hooks', () => {
       window.analytics = {
         track: jest.fn(),
       };
-      window.PRODUCT_TRACKING_KEY = 'account';
       window.location.href = 'http://localhost/the-path?query=the-query';
       window.location.pathname = '/the-path';
       window.location.search = '?query=the-query';
+      window.location.origin = 'https://account.buffer.com';
 
       useTrackPageViewed({
         payload: {

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -23,7 +23,7 @@ const ModalTesting = () => (<ModalContext.Consumer>
     {modal => (
       <>
         <h2>Render Modal</h2>
-        <button onClick={() => {modal.openModal(MODALS.planSelector, { cta: 'Render Modal', isUpgradeIntent: false })}}>Render Modal</button>
+        <button onClick={() => {modal.openModal(MODALS.planSelector, { cta: 'renderModal', ctaButton: 'renderModal', isUpgradeIntent: false })}}>Render Modal</button>
       </>
     )}
 </ModalContext.Consumer>)


### PR DESCRIPTION
Uses the `getProductPath ` method to extract the product name from the url, instead of the `PRODUCT_TRACKING_KEY` global.