### PR TITLE
[AT-891] Display the downgraded to free message in plan selector

### DIFF
--- a/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import Text from '@bufferapp/ui/Text';
 import Switch from '@bufferapp/ui/Switch';
 import Button from '@bufferapp/ui/Button';
+import Checkmark from '@bufferapp/ui/Icon/Icons/Checkmark';
 import { SelectionScreen } from './SelectionScreen';
 import Summary from '../../Summary';
 import useSelectedPlan from '../hooks/useSelectedPlan';
@@ -21,6 +22,7 @@ import {
   Container,
   AbsoluteSavings,
   HeaderLeft,
+  DowngradeMessage,
 } from '../style';
 import useInterval from '../hooks/useInterval';
 import { ModalContext } from '../../context/Modal';
@@ -134,6 +136,12 @@ export const PlanSelectorContainer = ({
             </HeaderLeft>
           )}
         </PlanSelectorHeader>
+        {selectedPlan.downgradedMessage && (
+          <DowngradeMessage>
+            <Checkmark />
+            <Text>{selectedPlan.downgradedMessage}</Text>
+          </DowngradeMessage>
+        )}
         <SelectionScreen
           planOptions={planOptions}
           selectedPlan={selectedPlan}

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -272,3 +272,22 @@ export const Benefit = styled.li`
     margin-right: 8px;
   }
 `;
+
+export const DowngradeMessage = styled.li`
+  display: flex;
+  margin-bottom: 20px;
+  margin-top: -10px;
+  max-width: 610px;
+  font-family: 'Roboto', sans-serif;
+  font-weight: bold;
+  font-size: 14px;
+  color: ${blue};
+
+  svg {
+    fill: ${blue};
+    height: 22px;
+    width: 22px;
+    margin-top: -4px;
+    margin-right: 5px;
+  }
+`;

--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -73,6 +73,7 @@ export const QUERY_ACCOUNT = gql`
                 intervalUnit
               }
               isRecommended
+              downgradedMessage
             }
           }
         }
@@ -130,6 +131,7 @@ export const QUERY_ACCOUNT = gql`
                 intervalUnit
               }
               isRecommended
+              downgradedMessage
             }
           }
         }


### PR DESCRIPTION
Displays the downgraded to free messages, when the subscription is downgraded to free from a paid, but it will be canceled by the end of the current billing period. 

@gmzjuliana take a good look at the css. I just copied pieces from the other parts of the application to make it look like design.

<img width="1057" alt="Screen Shot 2021-03-31 at 18 22 51" src="https://user-images.githubusercontent.com/1632257/113178747-2b369080-924f-11eb-9cbd-426b252fb09c.png">

<img width="1094" alt="Screen Shot 2021-03-31 at 18 19 38" src="https://user-images.githubusercontent.com/1632257/113178782-338ecb80-924f-11eb-85dc-c8fb6dde08d4.png">

<img width="1054" alt="Screen Shot 2021-03-31 at 18 23 43" src="https://user-images.githubusercontent.com/1632257/113178792-3689bc00-924f-11eb-8945-d37e50ebb05e.png">