### PR TITLE
Fix start trial and payment methods retry

### DIFF
--- a/packages/app-shell/src/PaymentMethod/components/Form.jsx
+++ b/packages/app-shell/src/PaymentMethod/components/Form.jsx
@@ -32,9 +32,10 @@ const Form = ({
   const [submitEnabled, setSubmitEnabled] = useState(false);
   const [hasPaymentMethod, setHasPaymentMethod] = useState(false);
   const [error, setError] = useState(null);
+  const [processing, setProcessing] = useState(false);
 
-  const { setupIntent } = useSetupIntent(user);
-  const { error:newPaymentMethodError, paymentMethod, processing, submit } = useCreatePaymentMethod(
+  const { setupIntent, error:setupIntentError } = useSetupIntent(user);
+  const { error:newPaymentMethodError, paymentMethod, submit } = useCreatePaymentMethod(
     setupIntent
   );
 
@@ -61,6 +62,9 @@ const Form = ({
   }, [userPaymentMethod]);
 
   useEffect(() => {
+    //re-enable form submit in case of errors
+    setProcessing(false);
+
     if(updatePaymentMethodError ){
       setError(updatePaymentMethodError)
     }
@@ -70,7 +74,10 @@ const Form = ({
     if(subscriptionPlanError){
       setError(subscriptionPlanError)
     }
-  }, [updatePaymentMethodError, newPaymentMethodError, subscriptionPlanError])
+    if(setupIntentError){
+      setError(setupIntentError)
+    }
+  }, [updatePaymentMethodError, newPaymentMethodError, subscriptionPlanError, setupIntentError])
 
   useEffect(() => {
     if (newPlan?.billingUpdateSubscriptionPlan.success) {
@@ -126,7 +133,10 @@ const Form = ({
         <ButtonContainer>
           <Button
             type="primary"
-            onClick={submit}
+            onClick={(e) => {
+              setProcessing(true)
+              submit(e)
+            }}
             disabled={!submitEnabled || processing}
             label={getButtonLabel()}
             fullWidth

--- a/packages/app-shell/src/PaymentMethod/hooks/useCreatePaymentMethod.js
+++ b/packages/app-shell/src/PaymentMethod/hooks/useCreatePaymentMethod.js
@@ -30,6 +30,7 @@ function useCreatePaymentMethod(setupIntent) {
       .then(({ error }) => {
         if (error) {
           setProcessingError(error);
+          setProcessing(false);
           return;
         }
 

--- a/packages/app-shell/src/StartTrial/index.jsx
+++ b/packages/app-shell/src/StartTrial/index.jsx
@@ -41,12 +41,12 @@ const StartTrial = ({ user, openModal }) => {
   );
 
   useEffect(() => {
-    if (trial.billingStartTrial.success) {
+    if (trial?.billingStartTrial.success) {
       openModal(MODALS.success, { startedTrial: true });
     } else if (mutationError) {
       setError(mutationError);
-    } else if (trial.billingStartTrial.userFriendlyMessage) {
-      setError(trial.billingStartTrial.userFriendlyMessage);
+    } else if (trial?.billingStartTrial.userFriendlyMessage) {
+      setError(trial?.billingStartTrial.userFriendlyMessage);
     }
   }, [trial, mutationError]);
 


### PR DESCRIPTION
fixes:
- No error message displayed when the very first API call (createSetupIntent) errors
- Confirm Payment Details CTA remains disabled after an error
- Uncaught TypeError: Cannot read property 'billingStartTrial' of undefined

[ref.](https://paper.dropbox.com/doc/One-Buffer-ANZ-Launch-QA-Issue-Tracking--BIVOHMRf2H3FifcVx21z5ACnAg-qQdBQN91aoL7nbJ6yayaa)