### PR TITLE
Plan Selector Tweaks 5

### DIFF
--- a/packages/app-shell/src/Confirmation/getCopy.js
+++ b/packages/app-shell/src/Confirmation/getCopy.js
@@ -3,8 +3,7 @@ const getCopy = ({ planName, startedTrial, onlyUpdatedCardDetails }) => {
   if (startedTrial) {
     return {
       label: 'Congrats! You are now starting your trial',
-      description:
-        'For the next 14 days you get to experience Buffer to it’s full. Have fun!',
+      description: 'You can now experience all Buffer has to offer. Have fun!',
       buttonCopy: SUCCESS_CTA,
     };
   }

--- a/packages/app-shell/src/Confirmation/getCopy.test.jsx
+++ b/packages/app-shell/src/Confirmation/getCopy.test.jsx
@@ -48,7 +48,7 @@ describe('getCopy', () => {
       'Congrats! You are now starting your trial'
     );
     expect(result.current.description).toBe(
-      'For the next 14 days you get to experience Buffer to it’s full. Have fun!'
+      'You can now experience all Buffer has to offer. Have fun!'
     );
     expect(result.current.buttonCopy).toBe(SUCCESS_CTA);
   });

--- a/packages/app-shell/src/PaymentMethod/components/Form.jsx
+++ b/packages/app-shell/src/PaymentMethod/components/Form.jsx
@@ -124,7 +124,7 @@ const Form = ({
             icon={<ArrowLeftIcon />}
           />
           <Text type="p">
-            <LockIcon size="medium" /> Payments are securely provided by Stripe
+            <LockIcon size="medium" /> Payments are securely processed by Stripe
           </Text>
         </Footer>
       </LeftSide>

--- a/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
+++ b/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Text from '@bufferapp/ui/Text';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
+import AddIcon from '@bufferapp/ui/Icon/Icons/Add';
 import {
   Wrapper,
   CardContainer,
@@ -13,6 +14,9 @@ import {
   BenefitList,
   Benefit,
 } from '../style';
+
+const ENTER_KEY = 13;
+const SPACE_KEY = 32;
 
 const Card = ({
   planId,
@@ -35,6 +39,10 @@ const Card = ({
       onClick={(e) => {
         updateSelectedPlan(e.currentTarget.id);
       }}
+      onKeyDown={(e) => {
+        if (e.keyCode === ENTER_KEY || e.keyCode === SPACE_KEY)
+          updateSelectedPlan(e.currentTarget.id);
+      }}
       id={`${planId}_${planInterval}`}
       selectedPlan={selectedPlan === planId}
       aria-label={selectedPlan === planId ? 'checked' : 'unchecked'}
@@ -42,7 +50,6 @@ const Card = ({
       {recommended && <Recommended>Recommended</Recommended>}
       <CardHeader>
         <Text type="h3">{planName}</Text>
-        {isCurrentPlan && <CurrentLabel>Current</CurrentLabel>}
       </CardHeader>
       <RadioButton selectedPlan={selectedPlan === planId}>
         <CheckmarkIcon size="large" />
@@ -54,7 +61,7 @@ const Card = ({
         <BenefitList>
           {highlights.map((benefit) => (
             <Benefit key={benefit}>
-              <CheckmarkIcon />
+              {planId === 'team' ? <AddIcon /> : <CheckmarkIcon />}
               <Text type="p">{benefit}</Text>
             </Benefit>
           ))}
@@ -64,18 +71,8 @@ const Card = ({
           <Text type="h2" as="p">
             {basePrice}
           </Text>
-          <sup
-            aria-label={
-              summary.intervalUnit === 'mo' ? 'per month' : 'per year'
-            }
-          >
-            {planId !== 'free' &&
-              `/${
-                summary.intervalUnit === 'mo' ? 'month' : 'month billed yearly'
-              }`}
-          </sup>
         </Price>
-        <Text htmlFor="foo" type="label" color="grayDark">
+        <Text type="label" color="grayDarker">
           {priceNote}
         </Text>
       </CardFooter>

--- a/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.js
+++ b/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { formatCTAString } from '../../hooks/useSegmentTracking'
+import { formatCTAString } from '../../hooks/useSegmentTracking';
 
 const useButtonOptions = ({
   selectedPlan,
@@ -11,7 +11,9 @@ const useButtonOptions = ({
 }) => {
   const getLabel = (selectedPlan) => {
     if (isActiveTrial) {
-      return hasPaymentDetails ? 'Confirm Trial Plan' : 'Go To Payment';
+      if (selectedPlan.planId === 'free') {
+        return 'Confirm Plan Change';
+      } else return hasPaymentDetails ? 'Confirm Trial Plan' : 'Go To Payment';
     } else if (selectedPlan?.isCurrentPlan) {
       if (selectedPlan.planId === 'free' && isAwaitingUserAction) {
         return 'Confirm Free Plan';
@@ -51,7 +53,7 @@ const useButtonOptions = ({
     label,
     action,
     updateButton,
-    ctaButton: formatCTAString(label)
+    ctaButton: formatCTAString(label),
   };
 };
 

--- a/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.js
+++ b/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.js
@@ -4,7 +4,7 @@ const useHeaderLabel = (isActiveTrial, planOptions, isFreePlan) => {
   let headerLabel;
 
   if (isActiveTrial) {
-    return { headerLabel: 'Upgrade from Trial' };
+    return { headerLabel: 'Confirm Trial Plan' };
   }
 
   const currentPlan = isFreePlan

--- a/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.test.jsx
@@ -2,11 +2,11 @@ import useHeaderLabel from './useHeaderLabel';
 import { renderHook } from '@testing-library/react-hooks';
 
 describe('useHeaderLabel', () => {
-  it("should set the header label to 'Upgrade from Trial' when a user is on a trial", () => {
+  it("should set the header label to 'Confirm Trial Plan' when a user is on a trial", () => {
     const isActiveTrial = true;
     const { result } = renderHook(() => useHeaderLabel(isActiveTrial));
 
-    expect(result.current.headerLabel).toBe('Upgrade from Trial');
+    expect(result.current.headerLabel).toBe('Confirm Trial Plan');
   });
   it("should set the header label to 'Change my plan' when a user changes plan", () => {
     const isActiveTrial = false;

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -1,9 +1,16 @@
-import { grayLighter, blue, grayDark, white } from '@bufferapp/ui/style/colors';
+import {
+  grayLighter,
+  blue,
+  grayDark,
+  white,
+  grayLight,
+  blueLighter,
+} from '@bufferapp/ui/style/colors';
 import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
-  height: 580px;
+  height: 610px;
   align-items: center;
   border-radius: 8px;
   box-sizing: border-box;
@@ -99,9 +106,13 @@ export const ButtonContainer = styled.div`
 
 export const Wrapper = styled.div`
   border: ${(props) =>
-    props.selectedPlan ? `2px solid ${blue}` : '2px solid rgb(224, 224, 224)'};
+    props.selectedPlan ? 'none' : `2px solid ${grayLight}`};
+  box-shadow: ${(props) =>
+    props.selectedPlan
+      ? `0px 0px 0px 1.5px #2c4bff, 0px 4px 8px rgba(0, 0, 0, 0.04)`
+      : `0px 4px 8px rgba(0, 0, 0, 0.04)`};
   border-radius: 3px;
-  height: 420px;
+  height: 450px;
   position: relative;
   padding: 21px;
   flex: 1 1 0px;
@@ -109,24 +120,25 @@ export const Wrapper = styled.div`
   box-sizing: border-box;
   background: ${white};
   cursor: pointer;
-  max-width: 250px;
+  width: 285px;
 
   p {
     font-weight: 500;
     margin: 0;
+    max-width: 200px;
   }
 
   h3 {
     margin: 0;
   }
 
-  &:focus {
-    border: 2px solid ${blue};
-    outline: none;
-  }
-
+  &:focus,
   &:hover {
-    border: 2px solid ${blue};
+    border: none;
+    box-shadow: ${(props) =>
+      props.selectedPlan
+        ? `0px 0px 0px 1.5px #2c4bff, 0px 4px 8px rgba(0, 0, 0, 0.04)`
+        : `0px 0px 0px 1.5px ${blueLighter}, 0px 4px 8px rgba(0, 0, 0, 0.04)`};
     outline: none;
   }
 `;
@@ -153,6 +165,10 @@ export const CardHeader = styled.div`
 export const CardFooter = styled.div`
   position: absolute;
   bottom: 21px;
+
+  label {
+    font-weight: 700;
+  }
 `;
 
 export const CurrentLabel = styled.label`
@@ -225,7 +241,7 @@ export const Price = styled.div`
 
   sup:first-child {
     font-weight: bold;
-    font-size: 16px;
+    font-size: 20px;
     line-height: 100%;
   }
 
@@ -240,6 +256,7 @@ export const Price = styled.div`
     margin-left: 2px;
     margin-right: 2px;
     font-weight: 600;
+    font-size: 26px;
   }
 `;
 

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -125,6 +125,9 @@ export const Wrapper = styled.div`
   p {
     font-weight: 500;
     margin: 0;
+  }
+
+  div + p {
     max-width: 200px;
   }
 

--- a/packages/app-shell/src/StartTrial/index.jsx
+++ b/packages/app-shell/src/StartTrial/index.jsx
@@ -92,7 +92,9 @@ const StartTrial = ({ user, openModal }) => {
                 console.error(e);
               });
             }}
-            label={processing ? 'Processing ...' : 'Start Free 14-day Trial'}
+            label={
+              processing ? 'Processing ...' : 'Start Free 14-day Free Trial'
+            }
           />
           <Button
             type="secondary"

--- a/packages/app-shell/src/StartTrial/style.js
+++ b/packages/app-shell/src/StartTrial/style.js
@@ -20,6 +20,11 @@ export const Holder = styled.div`
   h1 {
     color: ${black};
   }
+
+  h1 {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
 `;
 
 export const Content = styled.div`
@@ -29,12 +34,15 @@ export const Content = styled.div`
 
   p {
     margin-top: 0px;
+    margin-bottom: 14px;
     max-width: 282px;
   }
 
   ol {
     list-style: none;
     padding: 0;
+    margin-top: 16px;
+    margin-bottom: 16px;
 
     li {
       margin-bottom: 8px;
@@ -55,8 +63,7 @@ export const Content = styled.div`
 
 export const Ctas = styled.div`
   display: flex;
-    div:first-child {
-      margin-right: 8px;
-    }
+  div[type='primary'] {
+    margin-right: 8px;
   }
 `;

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -135,6 +135,26 @@ const Summary = ({
   const intervalInWords =
     selectedPlan.planInterval === 'month' ? '30 days' : 'year';
 
+  const getSummaryNote = () => {
+    if (isUpgradeIntent && trialInfo?.isActive) {
+      return (
+        <Text type="p">
+          You won't be charged until the end of your trial on{' '}
+          <span>{formattedTrialEndDate}</span>
+        </Text>
+      );
+    } else if (selectedPlan.planId === 'free' && subscriptionEndDate) {
+      return (
+        <Text type="p">
+          Changing to Free will occur at the end of your next billing cycle on{' '}
+          <span>{formattedSubscriptionEndDate}</span>
+        </Text>
+      );
+    } else if (selectedPlan.planId === 'free' && !subscriptionEndDate) {
+      return <Text type="p">Upgrade your plan at anytime</Text>;
+    } else return <Text type="p">Cancel your plan at anytime</Text>;
+  };
+
   return (
     <SummaryContainer>
       <Body>
@@ -150,16 +170,7 @@ const Summary = ({
               ))}
             </DetailList>
             <Separator />
-            <SummaryNote>
-              {selectedPlan.planId === 'free' && subscriptionEndDate ? (
-                <Text type="p">
-                  Changing to Free will occur at the end of your next billing
-                  cycle on <span>{formattedSubscriptionEndDate}</span>
-                </Text>
-              ) : (
-                <Text type="p">Cancel your plan at anytime</Text>
-              )}
-            </SummaryNote>
+            <SummaryNote>{getSummaryNote()}</SummaryNote>
           </>
         ) : (
           <>

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -96,7 +96,7 @@ const Summary = ({
         return null;
       }
       return (
-        <Text type="label" color="grayDark">
+        <Text type="label" color="grayDarker">
           {/* this ends up reading: # social channels x base price */}
           {`${selectedPlan.channelsQuantity} social channel${
             selectedPlan.channelsQuantity > 1 ? 's' : ''
@@ -111,7 +111,7 @@ const Summary = ({
       );
     } else {
       return (
-        <Text type="label" color="grayDark">
+        <Text type="label" color="grayDarker">
           Includes tax
         </Text>
       );
@@ -151,7 +151,7 @@ const Summary = ({
             </DetailList>
             <Separator />
             <SummaryNote>
-              {selectedPlan.planId === 'free' ? (
+              {selectedPlan.planId === 'free' && subscriptionEndDate ? (
                 <Text type="p">
                   Changing to Free will occur at the end of your next billing
                   cycle on <span>{formattedSubscriptionEndDate}</span>

--- a/packages/app-shell/src/Summary/style.js
+++ b/packages/app-shell/src/Summary/style.js
@@ -2,7 +2,7 @@ import { blue, grayDark, grayDarker } from '@bufferapp/ui/style/colors';
 import styled, { css } from 'styled-components';
 
 export const SummaryContainer = styled.div`
-  width: 255px;
+  width: 285px;
   background-color: #fcfcfc;
   border-top-right-radius: 8px;
   border-bottom-right-radius: 8px;
@@ -27,6 +27,7 @@ export const Bottom = styled.div`
   label {
     display: inline-block;
     margin-bottom: 8px;
+    font-weight: 700;
   }
 `;
 
@@ -143,8 +144,8 @@ export const Separator = styled.span`
   width: 100%;
   display: block;
   background-color: #eeeeee;
-  margin-bottom: 12px;
-  margin-top: 12px;
+  margin-bottom: 16px;
+  margin-top: 16px;
 `;
 
 export const SummaryNote = styled.div`

--- a/packages/app-shell/src/index.jsx
+++ b/packages/app-shell/src/index.jsx
@@ -62,7 +62,12 @@ const AppShell = ({
 
   let isActiveTrial;
   let trialBannerString;
-  if (user.currentOrganization?.isOneBufferOrganization) {
+  //in human: is OB, is admin, doesn't have payment details
+  if (
+    user.currentOrganization?.isOneBufferOrganization &&
+    user.currentOrganization?.canEdit &&
+    !user.currentOrganization?.billing.paymentDetails.hasPaymentDetails
+  ) {
     isActiveTrial =
       user.currentOrganization?.billing?.subscription?.trial?.isActive;
     if (isActiveTrial) {


### PR DESCRIPTION
In this edition: 
- fix spacing and button copy in Start Trial modal
- tweaks to the trial banner display logic (show on trial, to admins, when there's not billing info)
- style tweaks to the plan selector cards and summary
- summary logic tweaks to summary note