### PR TITLE
Default potentially null query data when updating cache

### DIFF
--- a/packages/app-shell/src/hooks/useOrgSwitcher.js
+++ b/packages/app-shell/src/hooks/useOrgSwitcher.js
@@ -5,7 +5,7 @@ function useOrgSwitcher() {
   const [setCurrentOrganization] = useMutation(SET_CURRENT_ORGANIZATION);
 
   const updateCache = (organizationId, client) => {
-    const previousData = client.readQuery({ query: QUERY_ACCOUNT });
+    const previousData = client.readQuery({ query: QUERY_ACCOUNT }) || {};
     const organizationSelected = previousData?.account?.organizations?.filter(
       (organization) => organization.id === organizationId
     )[0];


### PR DESCRIPTION
While I tried to use the org-switcher in production in https://account.buffer.com, I got the following error
<img width="564" alt="Screen Shot 2021-04-12 at 08 08 05" src="https://user-images.githubusercontent.com/1632257/114348158-73ff1b00-9b66-11eb-8352-bea9d608d9a8.png">

I tried with the analytics app and I got that as well, while trying to impersonate several users and I was able to get the error quite often. When I tried to simulate the error locally it pointed to the apollo client query and this is how I found this line. 

I believe I understand what is happening and I have a theory, but I was not able to think of a proper solution and therefore this "defensive" patch that at least prevents the error and recovers the functionality. 

I have some assumptions though 😅 
In the analytics app we have other graphql queries as well for the account, one for fetching the `canAccessAnalytics` flag, which is not needed anymore and one for fetching the account channels. The account app does the same and actually the org-switcher stops working after visiting the https://account.buffer.com/channels page. 
I don't know how apollo client caching is working but I'm afraid that fetching the same object with various forms might be causing the issue. 