### PR TITLE
Rename individual plan instances to essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const ModalTesting = () => (
 In the method above, you'll notice that openModal accepts an object as a second paramater. The cta property is used for tracking. Use it when possible to allow for accurate tracking in Segment
 
 #### Using intentions
-Some places in our apps, the user's intent is to upgrade from Trial or from Free. For that, we only want to show 2 plan options (Individual and Team) instead of 3. For these CTAs, pass in `isUpgradeIntent : true` as part of the second paramater in openModal:
+Some places in our apps, the user's intent is to upgrade from Trial or from Free. For that, we only want to show 2 plan options (Essentials and Team) instead of 3. For these CTAs, pass in `isUpgradeIntent : true` as part of the second paramater in openModal:
 ```
 <button onClick={
     () => {modal.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'upgradePlan', isUpgradeIntent: true })}

--- a/packages/app-shell/src/Confirmation/getCopy.test.jsx
+++ b/packages/app-shell/src/Confirmation/getCopy.test.jsx
@@ -2,7 +2,7 @@ import getCopy, { SUCCESS_CTA } from './getCopy';
 import { renderHook } from '@testing-library/react-hooks';
 
 describe('getCopy', () => {
-  it('should return label, description and buttonCopy for a team/individual plan change', () => {
+  it('should return label, description and buttonCopy for a team/essentials plan change', () => {
     const planName = 'Team';
 
     const { result } = renderHook(() => getCopy({ planName }));

--- a/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useButtonOptions.test.jsx
@@ -161,7 +161,7 @@ describe('useButtonOptions', () => {
     };
 
     const newPlan = {
-      planId: 'individual',
+      planId: 'essentials',
       isCurrentPlan: false,
     };
 

--- a/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useHeaderLabel.test.jsx
@@ -10,7 +10,7 @@ describe('useHeaderLabel', () => {
   });
   it("should set the header label to 'Change my plan' when a user changes plan", () => {
     const isActiveTrial = false;
-    const planOptions = [{ planId: 'individual', isCurrentPlan: true }];
+    const planOptions = [{ planId: 'essentials', isCurrentPlan: true }];
     const { result } = renderHook(() =>
       useHeaderLabel(isActiveTrial, planOptions)
     );

--- a/packages/app-shell/src/PlanSelector/hooks/useInterval.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useInterval.test.jsx
@@ -14,7 +14,7 @@ describe('useInterval', () => {
   });
   it("should set the initial interval to month if it's a free plan", () => {
     const planOptions = [
-      { planId: 'individual', planInterval: 'month', isCurrentPlan: false },
+      { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
       { planId: 'team', planInterval: 'month', isCurrentPlan: false },
     ];
 

--- a/packages/app-shell/src/PlanSelector/hooks/useSelectedPlan.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useSelectedPlan.test.jsx
@@ -2,7 +2,7 @@ import useSelectedPlan from './useSelectedPlan';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 const planOptions = [
-  { planId: 'individual', isCurrentPlan: false, planInterval: 'year' },
+  { planId: 'essentials', isCurrentPlan: false, planInterval: 'year' },
   { planId: 'team', isCurrentPlan: true, planInterval: 'year' },
   { planId: 'free', planInterval: 'month' },
 ];
@@ -12,7 +12,7 @@ describe('useSelectedPlan', () => {
     const { result } = renderHook(() => useSelectedPlan(planOptions));
     expect(result.current.selectedPlan.planId).toBe('team');
   });
-  it('should set the default as the individual plan if the intent is to upgrade', () => {
+  it('should set the default as the essentials plan if the intent is to upgrade', () => {
     const isUpgradeIntent = true;
 
     const { result } = renderHook(() =>
@@ -21,13 +21,13 @@ describe('useSelectedPlan', () => {
     expect(result.current.selectedPlan.planId).toBe('team');
   });
   it('should update the selected plan', () => {
-    const planString = 'individual_year';
+    const planString = 'essentials_year';
 
     const { result } = renderHook(() => useSelectedPlan(planOptions));
     act(() => {
       result.current.updateSelectedPlan(planString);
     });
-    expect(result.current.selectedPlan.planId).toBe('individual');
+    expect(result.current.selectedPlan.planId).toBe('essentials');
   });
   it('should update the selected plan with a new interval', () => {
     const planString = 'free_month';

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -17,7 +17,6 @@ import {
   SummaryNote,
 } from './style';
 import { UserContext } from '../context/User';
-import { freePlan } from '../mocks/freePlan';
 
 const Summary = ({
   planOptions,
@@ -34,7 +33,7 @@ const Summary = ({
     : '';
 
   const isDowngrading = (currentPlanId, selectedPlanId) => {
-    if (currentPlanId === 'individual') {
+    if (currentPlanId === 'essentials') {
       return selectedPlanId === 'free' ? true : false;
     }
     if (currentPlanId === 'team') {

--- a/packages/app-shell/src/hooks/useSegmentTracking.test.js
+++ b/packages/app-shell/src/hooks/useSegmentTracking.test.js
@@ -45,7 +45,7 @@ describe('useSegmentTracking hooks', () => {
       useTrackPlanSelectorViewed({
         payload: {
           screenName: 'changeMyPlan',
-          currentPlan: 'individualMonth',
+          currentPlan: 'essentialsMonth',
           cta: 'upgradePlan',
         },
         user: {
@@ -62,7 +62,7 @@ describe('useSegmentTracking hooks', () => {
           organizationId: '123-test-org',
           ctaApp: 'analyze',
           ctaVersion: '1',
-          currentPlan: 'individualMonth',
+          currentPlan: 'essentialsMonth',
           screenName: 'changeMyPlan',
           ctaLocation: 'appShell',
           cta: 'analyze-upgradePlan-planSelectorViewed',

--- a/packages/app-shell/src/hooks/useUpdateSubscriptionPlan.test.jsx
+++ b/packages/app-shell/src/hooks/useUpdateSubscriptionPlan.test.jsx
@@ -33,7 +33,7 @@ describe('useUpdateSubscriptionPlan', () => {
     },
   };
   const plan = {
-    planId: 'individual',
+    planId: 'essentials',
     planInterval: 'year',
   };
   const userWithError = {

--- a/packages/app-shell/src/mocks/mock.js
+++ b/packages/app-shell/src/mocks/mock.js
@@ -42,8 +42,8 @@ export default {
               isRecommended: false,
             },
             {
-              planId: 'individual',
-              planName: 'Individual',
+              planId: 'essentials',
+              planName: 'Essentials',
               planInterval: 'month',
               channelsQuantity: 1,
               description:
@@ -117,8 +117,8 @@ export default {
               isRecommended: false,
             },
             {
-              planId: 'individual',
-              planName: 'Individual',
+              planId: 'essentials',
+              planName: 'Essentials',
               planInterval: 'year',
               channelsQuantity: 1,
               description:


### PR DESCRIPTION
Renames the individual plan instances to essentials.
This change has a server side dependency https://github.com/bufferapp/core-authentication-service/pull/912