### PR TITLE
Summary note and copy tweaks

### DIFF
--- a/packages/app-shell/src/PaymentMethod/components/Form.jsx
+++ b/packages/app-shell/src/PaymentMethod/components/Form.jsx
@@ -124,7 +124,7 @@ const Form = ({
             icon={<ArrowLeftIcon />}
           />
           <Text type="p">
-            <LockIcon size="medium" /> Payments are securely processed by Stripe
+            <LockIcon size="medium" /> Payments securely processed by Stripe
           </Text>
         </Footer>
       </LeftSide>

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -135,7 +135,7 @@ const Summary = ({
     selectedPlan.planInterval === 'month' ? '30 days' : 'year';
 
   const getSummaryNote = () => {
-    if (isUpgradeIntent && trialInfo?.isActive) {
+    if (trialInfo?.isActive) {
       return (
         <Text type="p">
           You won't be charged until the end of your trial on{' '}


### PR DESCRIPTION
- Show all trial users the summary note that they won't be charged till the end of their trial
- fix stripe copy in payment method