### PR TITLE
remove the MPBilling trial field that was preventing the query from resolving

### DIFF
--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -41,9 +41,6 @@ export const QUERY_ACCOUNT = gql`
             subscriptions {
               plan
               product
-              trial {
-                isActive
-              }
             }
           }
           ... on OBBilling {

--- a/packages/app-shell/src/index.jsx
+++ b/packages/app-shell/src/index.jsx
@@ -42,6 +42,11 @@ const AppShell = ({
       }
     : {};
   const { data, loading, error } = useQuery(QUERY_ACCOUNT, graphqlConfig);
+  window.__userData = {
+    data,
+    loading,
+    error,
+  }
 
   const user =
     loading || !data


### PR DESCRIPTION
This is a temporary solution, we will need to fix this on the BE, making sure the `trial` is set to `null`, when missing for `MPUsers` instead of getting omitted.