### PR TITLE
return MPSubscription trial and Subscription interval

### DIFF
--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -39,13 +39,18 @@ export const QUERY_ACCOUNT = gql`
           ... on MPBilling {
             billingRedirectUrl
             subscriptions {
+              interval
               plan
               product
+              trial {
+                isActive
+              }
             }
           }
           ... on OBBilling {
             canStartTrial
             subscription {
+              interval
               periodEnd
               trial {
                 isActive
@@ -103,13 +108,18 @@ export const QUERY_ACCOUNT = gql`
           ... on MPBilling {
             billingRedirectUrl
             subscriptions {
+              interval
               plan
               product
+              trial {
+                isActive
+              }
             }
           }
           ... on OBBilling {
             canStartTrial
             subscription {
+              interval
               periodEnd
               trial {
                 isActive


### PR DESCRIPTION
This fixes the issue with the `trial` and `interval` fields causing the queries to fail.

The problem was caused by Apollo Cache failing to resolving the subscription data because those fields were only present in the `currentOrganization` query but not in the `organization`.
We really need to start returning `id` for all the relevant fields to avoid this issue.