### PR TITLE
Plan selector updgrades

### DIFF
--- a/packages/app-shell/.storybook/main.js
+++ b/packages/app-shell/.storybook/main.js
@@ -2,10 +2,11 @@ module.exports = {
   "stories": [
     "../src/**/*.stories.mdx",
     "../src/**/*.stories.@(js|jsx|ts|tsx)",
-    "../src/**/components/*.stories.@(js|jsx|ts|tsx)"
+    "../src/**/components/*.stories.@(js|jsx|ts|tsx)",
   ],
   "addons": [
     "@storybook/addon-links",
-    "@storybook/addon-essentials"
+    "@storybook/addon-essentials",
+    "storybook-addon-apollo-client",
   ]
 }

--- a/packages/app-shell/.storybook/preview.js
+++ b/packages/app-shell/.storybook/preview.js
@@ -1,4 +1,7 @@
+import { MockedProvider } from '@apollo/client/testing'; 
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  apolloClient: {
+    MockedProvider,
+  },
 }

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -55,6 +55,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "storybook-addon-apollo-client": "^4.0.8",
     "styled-components": "^5.2.0"
   },
   "peerDependencies": {

--- a/packages/app-shell/src/Confirmation/getCopy.js
+++ b/packages/app-shell/src/Confirmation/getCopy.js
@@ -1,3 +1,7 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+import Link from '@bufferapp/ui/Link';
+
 export const SUCCESS_CTA = "Great, Let's Go!";
 const getCopy = ({ planName, startedTrial }) => {
   if (startedTrial) {
@@ -24,6 +28,7 @@ const getCopy = ({ planName, startedTrial }) => {
       description: `Your details have gone through successfully. Start using your ${planName} plan features.`,
       buttonCopy: SUCCESS_CTA,
       imageUrl: 'https://buffer-ui.s3.amazonaws.com/illustration-celebrate.png',
+      footer: (<Text type='p'>You can always access your invoices and billing information <Link href='https://account.buffer.com/billing'>here</Link>.</Text>)
     };
   }
 

--- a/packages/app-shell/src/Confirmation/index.jsx
+++ b/packages/app-shell/src/Confirmation/index.jsx
@@ -12,7 +12,7 @@ const ScreenContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 800px;
-  height: 376px;
+  height: ${({ planId }) => planId === 'team' ? '446px' : '376px'};
   box-sizing: border-box;
   background-repeat: no-repeat;
   background-position-x: right;
@@ -36,11 +36,16 @@ const ScreenContainer = styled.div`
     margin-top: 0px;
     max-width: 282px;
   }
+
+  p:last-child {
+    font-style: italic;
+  }
 `;
 
 const ButtonContainer = styled.div`
   width: fit-content;
   margin-top: 32px;
+  margin-bottom: 32px;
 `;
 
 const Screen = ({
@@ -50,7 +55,7 @@ const Screen = ({
   closeModal,
 }) => {
   const planName = selectedPlan ? selectedPlan.planName : null;
-  const { label, description, buttonCopy, imageUrl } = getCopy({
+  const { label, description, buttonCopy, imageUrl, footer } = getCopy({
     planName,
     onlyUpdatedCardDetails,
     startedTrial,
@@ -72,7 +77,7 @@ const Screen = ({
   }, []);
 
   return (
-    <ScreenContainer imageUrl={imageUrl}>
+    <ScreenContainer planId={selectedPlan.planId} imageUrl={imageUrl}>
       <Text type="h1">{label}</Text>
       <Text type="p">{description}</Text>
       <ButtonContainer>
@@ -84,6 +89,7 @@ const Screen = ({
           label={buttonCopy}
         />
       </ButtonContainer>
+      {footer && footer}
     </ScreenContainer>
   );
 };

--- a/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/NavBar/components/UpgradeCTA.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { blue } from '@bufferapp/ui/style/colors';
 import Button from '@bufferapp/ui/Button';
 import FlashIcon from '@bufferapp/ui/Icon/Icons/Flash';
+import PeopleIcon from '@bufferapp/ui/Icon/Icons/People';
 
 import { UserContext } from '../../context/User';
 import { ModalContext } from '../../context/Modal';
@@ -27,12 +28,26 @@ const UpgradeCTA = () => {
         const { currentOrganization } = user;
         const { isOneBufferOrganization } = currentOrganization;
         const isFree = isFreePlan(user);
-        const [hostname, envModifier] = window.location.hostname.match(/\w+(\.\w+)\.buffer\.com/) || [null, null]
+        const [hostname, envModifier] = window.location.hostname.match(/\w+\.(\w+\.)buffer\.com/) || [null, null]
 
+
+        if (currentOrganization.shouldDisplayInviteCTA) {
+          return (
+            <Cta>
+              <Button
+                type="text"
+                onClick={() => {
+                  window.location = `https://${envModifier}buffer.com/manage/${currentOrganization.id}/team-members/invite`;
+                }}
+                icon={<PeopleIcon />}
+                label="Invite Your Team"
+              />
+            </Cta>
+          )
+        }
 
         if (currentOrganization.billing) {
           const { canStartTrial } = currentOrganization.billing;
-
           return (
             <ModalContext.Consumer>
               {({ openModal }) => (
@@ -56,7 +71,7 @@ const UpgradeCTA = () => {
                               });
                             }
                           } else {
-                            window.location = `https://account${envModifier}.buffer.com/billing`;
+                            window.location = `https://account.${envModifier}buffer.com/billing`;
                           }
                         }}
                         icon={<FlashIcon />}

--- a/packages/app-shell/src/NavBar/index.jsx
+++ b/packages/app-shell/src/NavBar/index.jsx
@@ -13,6 +13,7 @@ import PinterestIcon from '@bufferapp/ui/Icon/Icons/Pinterest';
 import LinkedInIcon from '@bufferapp/ui/Icon/Icons/LinkedIn';
 import ShopifyIcon from '@bufferapp/ui/Icon/Icons/Shopify';
 import FlashIcon from '@bufferapp/ui/Icon/Icons/Flash';
+import PeopleIcon from '@bufferapp/ui/Icon/Icons/People';
 
 import {
   blue,
@@ -65,11 +66,15 @@ export function getAccountUrl(baseUrl = '', user) {
   )}&username=${encodeURI(user.name)}`;
 }
 
-export function getBillingUrl(baseUrl = '') {
-  const productPath = getProductPath(baseUrl);
-  return `https://account${
-    productPath.includes('local') ? '.local' : ''
-  }.buffer.com/billing`;
+export function getBillingUrl() {
+  const [hostname, envModifier] = window.location.hostname.match(/\w+\.(\w+\.)buffer\.com/) || [null, null]
+  return `https://account.${envModifier}buffer.com/billing`;
+}
+
+export function getTeamManageUrl(user) {
+  const [hostname, envModifier] = window.location.hostname.match(/\w+\.(\w+\.)buffer\.com/) || [null, null]
+  return `https://${envModifier}buffer.com/manage/${user.currentOrganization.id}/team-members/invite
+  `
 }
 
 export const ORG_SWITCHER = 'org_switcher';
@@ -275,6 +280,7 @@ const NavBar = React.memo((props) => {
   let subscription = null;
   let canStartTrial = false;
   let isOneBufferOrganization = false;
+  const shouldDisplayInviteCTA =  user?.currentOrganization?.shouldDisplayInviteCTA;
   if (user.currentOrganization.billing) {
     subscription = user?.currentOrganization?.billing?.subscription;
     canStartTrial = user?.currentOrganization?.billing.canStartTrial;
@@ -333,6 +339,16 @@ const NavBar = React.memo((props) => {
                   },
                 }),
                 ...menuItems,
+                (shouldDisplayInviteCTA) ? {
+                  id: 'Invite Your Team',
+                  title: 'Invite Your Team',
+                  icon: <PeopleIcon color={blue} />,
+                  colors: { title: 'blue', iconHover: 'blueDaker' },
+                  hasDivider: true,
+                  onItemClick: () => {
+                    window.location = getTeamManageUrl(user)
+                  },
+                } : null,
                 (isFree && !isOneBufferOrganization) ? {
                   id: 'upgrade',
                   title: 'Upgrade',
@@ -340,7 +356,7 @@ const NavBar = React.memo((props) => {
                   colors: { title: 'blue', iconHover: 'blueDaker' },
                   hasDivider: true,
                   onItemClick: () => {
-                    window.location = getBillingUrl(window.location.href)
+                    window.location = getBillingUrl()
                   },
                 } : null,
                 (isFree && !canStartTrial && isOneBufferOrganization) ? {

--- a/packages/app-shell/src/PaymentMethod/PaymentMethod.stories.js
+++ b/packages/app-shell/src/PaymentMethod/PaymentMethod.stories.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PaymentMethod from './index';
+import { UserContext } from '../context/User';
+import { ModalContext } from '../context/Modal';
+import mock from '../mocks/mock';
+import { CREATE_SETUP_INTENT } from '../graphql/billing';
+
+export default {
+  title: 'Payment Method',
+  component: PaymentMethod,
+};
+
+const Template = (args) => (
+  <UserContext.Provider value={mock.data.account}>
+    <ModalContext.Provider value={{
+      modal: null,
+        data: { plan: mock.data.account.currentOrganization.billing.changePlanOptions[1] }
+    }}>
+      <PaymentMethod {...args} />
+    </ModalContext.Provider>
+  </UserContext.Provider>
+);
+
+export const AnotherExample = Template.bind({});
+AnotherExample.args = {
+  user: mock.data.account,
+};
+
+AnotherExample.parameters = {
+  apolloClient: {
+    mocks: [
+      {
+        request: {
+          query: CREATE_SETUP_INTENT,
+          variables: {
+            organizationId: mock.data.account.currentOrganization.id,
+          },
+        },
+        result: {
+          data: {
+            billingCreateSetupIntent: {
+              success: true,
+              clientSecret: 'fooSetupIntent',
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: CREATE_SETUP_INTENT,
+          variables: {
+            organizationId: mock.data.account.currentOrganization.id,
+          },
+        },
+        result: {
+          data: {
+            billingCreateSetupIntent: {
+              success: true,
+              clientSecret: 'fooSetupIntent',
+            },
+          },
+        },
+      },
+    ]
+  }
+};

--- a/packages/app-shell/src/PaymentMethod/style.js
+++ b/packages/app-shell/src/PaymentMethod/style.js
@@ -127,7 +127,7 @@ export const DoubleFields = styled.div`
 export const LeftSide = styled.div`
   box-sizing: border-box;
   display: flex;
-  padding: 24px;
+  padding: 36px 24px 24px 24px;
   width: 665px;
   flex-direction: column;
   ${Footer} {

--- a/packages/app-shell/src/PaymentMethod/style.js
+++ b/packages/app-shell/src/PaymentMethod/style.js
@@ -48,7 +48,7 @@ export const Error = ({ isInline, error }) => (
 
 export const Form = styled.form`
   display: flex;
-  height: 415px;
+  height: 580px;
   width: 920px;
   box-sizing: border-box;
 
@@ -131,9 +131,15 @@ export const LeftSide = styled.div`
   width: 665px;
   flex-direction: column;
   ${Footer} {
+    margin-top: auto;
+
     button {
       color: ${blue};
       padding: 0px;
+    }
+
+    p {
+      margin: 0px;
     }
   }
 
@@ -156,7 +162,6 @@ export const RightSide = styled.div`
 `;
 
 export const ButtonContainer = styled.div`
-  background: #f5f5f5;
   border-bottom-right-radius: 8px;
   height: 88px;
   padding: 24px 20px;

--- a/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.jsx
@@ -128,7 +128,7 @@ export const PlanSelectorContainer = ({
   }, [data, subscriptionError]);
 
   return (
-    <Container>
+    <Container downgradedMessage={selectedPlan?.downgradedMessage}>
       <Left>
         <PlanSelectorHeader>
           <Text type="h2">{headerLabel}</Text>

--- a/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.stories.js
+++ b/packages/app-shell/src/PlanSelector/components/PlanSelectorContainer.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PlanSelectorContainer } from './PlanSelectorContainer';
+import { UserContext } from '../../context/User';
 import response from '../../mocks/mock';
 
 export default {
@@ -7,10 +8,15 @@ export default {
   component: PlanSelectorContainer,
 };
 
-const Template = (args) => <PlanSelectorContainer {...args} />;
+const Template = (args) => (
+  <UserContext.Provider value={response.data.account}>
+    <PlanSelectorContainer {...args} />
+  </UserContext.Provider>
+);
 
 export const AnotherExample = Template.bind({});
 AnotherExample.args = {
-  planOptions:
+  user: response.data.account,
+  changePlanOptions:
     response.data.account.currentOrganization.billing.changePlanOptions,
 };

--- a/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
+++ b/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Text from '@bufferapp/ui/Text';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
-import AddIcon from '@bufferapp/ui/Icon/Icons/Add';
 import {
   Wrapper,
   CardContainer,
@@ -9,10 +8,10 @@ import {
   CardFooter,
   CurrentLabel,
   Recommended,
-  RadioButton,
   Price,
   BenefitList,
   Benefit,
+  Check
 } from '../style';
 
 const ENTER_KEY = 13;
@@ -33,6 +32,7 @@ const Card = ({
   selectedPlan,
   recommended,
 }) => {
+  const isSelectedPlan = selectedPlan === planId;
   return (
     <Wrapper
       tabIndex="0"
@@ -44,34 +44,40 @@ const Card = ({
           updateSelectedPlan(e.currentTarget.id);
       }}
       id={`${planId}_${planInterval}`}
-      selectedPlan={selectedPlan === planId}
-      aria-label={selectedPlan === planId ? 'checked' : 'unchecked'}
+      isSelectedPlan={isSelectedPlan}
+      aria-label={isSelectedPlan ? 'checked' : 'unchecked'}
     >
       {recommended && <Recommended>Recommended</Recommended>}
       <CardHeader>
-        <Text type="h3">{planName}</Text>
+        <Text type="h2">{planName}</Text>
+        <Check isSelectedPlan={isSelectedPlan}><CheckmarkIcon size="medium" /></Check>
       </CardHeader>
 
       <Text type="p">{description}</Text>
 
       <CardFooter>
-        <BenefitList>
-          {highlights.map((benefit) => (
-            <Benefit key={benefit}>
-              {planId === 'team' ? <AddIcon /> : <CheckmarkIcon />}
-              <Text type="p">{benefit}</Text>
-            </Benefit>
-          ))}
-        </BenefitList>
         <Price>
           <sup>{currency}</sup>
           <Text type="h2" as="p">
             {basePrice}
           </Text>
         </Price>
-        <Text type="label" color="grayDarker">
+        <Text type="label" color="grayDark">
           {priceNote}
         </Text>
+        <BenefitList>
+          <Text type="h3">
+            Features
+          </Text>
+          <ul>
+            {highlights.map((benefit) => (
+              <Benefit key={benefit}>
+                <CheckmarkIcon />
+                <Text type="p">{benefit}</Text>
+              </Benefit>
+            ))}
+          </ul>
+        </BenefitList>
       </CardFooter>
     </Wrapper>
   );

--- a/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
+++ b/packages/app-shell/src/PlanSelector/components/SelectionScreen.jsx
@@ -30,7 +30,6 @@ const Card = ({
   isCurrentPlan,
   updateSelectedPlan,
   selectedPlan,
-  recommended,
 }) => {
   const isSelectedPlan = selectedPlan === planId;
   return (
@@ -47,7 +46,6 @@ const Card = ({
       isSelectedPlan={isSelectedPlan}
       aria-label={isSelectedPlan ? 'checked' : 'unchecked'}
     >
-      {recommended && <Recommended>Recommended</Recommended>}
       <CardHeader>
         <Text type="h2">{planName}</Text>
         <Check isSelectedPlan={isSelectedPlan}><CheckmarkIcon size="medium" /></Check>
@@ -106,7 +104,7 @@ export const SelectionScreen = ({
             key={`${option.planId}_${option.planInterval}`}
             updateSelectedPlan={updateSelectedPlan}
             selectedPlan={selectedPlan.planId}
-            recommended={option.isRecommended}
+            recommended={false}
           />
         ))}
     </CardContainer>

--- a/packages/app-shell/src/PlanSelector/hooks/useInterval.js
+++ b/packages/app-shell/src/PlanSelector/hooks/useInterval.js
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { freePlan } from '../../mocks/freePlan';
 
 const useInterval = (planOptions, isUpgradeIntent) => {
   const defaultSelectedPlan = isUpgradeIntent
     ? planOptions[1]
     : planOptions.find((plan) => plan.isCurrentPlan);
-  const initiallyMonthly = defaultSelectedPlan.planInterval === 'month';
+  const initiallyMonthly = isUpgradeIntent
+    ? false
+    : defaultSelectedPlan.planInterval === 'month';
   const [monthlyBilling, setBillingInterval] = useState(initiallyMonthly);
 
   return {

--- a/packages/app-shell/src/PlanSelector/hooks/useInterval.test.jsx
+++ b/packages/app-shell/src/PlanSelector/hooks/useInterval.test.jsx
@@ -12,7 +12,7 @@ describe('useInterval', () => {
 
     expect(result.current.monthlyBilling).toBe(true);
   });
-  it("should set the initial interval to month if it's a free plan", () => {
+  it("should set the initial interval to year if it's a free plan", () => {
     const planOptions = [
       { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
       { planId: 'team', planInterval: 'month', isCurrentPlan: false },
@@ -22,7 +22,7 @@ describe('useInterval', () => {
 
     const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
 
-    expect(result.current.monthlyBilling).toBe(true);
+    expect(result.current.monthlyBilling).toBeFalsy();
   });
   it('should change the current interval when updated', () => {
     const planOptions = [

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -105,9 +105,9 @@ export const ButtonContainer = styled.div`
 
 export const Wrapper = styled.div`
   border: ${(props) =>
-    props.selectedPlan ? '1.5px solid transparent' : `1.5px solid ${grayLight}`};
+    props.isSelectedPlan ? '1.5px solid transparent' : `1.5px solid ${grayLight}`};
   box-shadow: ${(props) =>
-    props.selectedPlan
+    props.isSelectedPlan
       ? `0px 0px 0px 1.5px ${blue}, 0px 4px 8px rgba(0, 0, 0, 0.04)`
       : `0px 4px 8px rgba(0, 0, 0, 0.04)`};
   border-radius: 3px;
@@ -141,7 +141,7 @@ export const Wrapper = styled.div`
   &:focus,
   &:hover {
     border: ${(props) =>
-      props.selectedPlan ? '1.5px solid transparent' : `1.5px solid ${blueLighter}`};
+      props.isSelectedPlan ? '1.5px solid transparent' : `1.5px solid ${blueLighter}`};
     outline: none;
   }
 `;
@@ -163,14 +163,39 @@ export const CardHeader = styled.div`
   align-items: center;
   height: 30px;
   margin-bottom: 16px;
+
+  h2 {
+    font-size: 18px;
+    line-height: 28px;
+  }
+`;
+
+export const Check = styled.div`
+  margin-left: auto;
+  border: 1.5px solid ${({ isSelectedPlan }) => isSelectedPlan ? blue : grayLight};
+  background: ${({ isSelectedPlan }) => isSelectedPlan ? blue : white};
+  box-sizing: border-box;
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    color: ${white};
+    width: 18px;
+    height: 18px;
+  }
 `;
 
 export const CardFooter = styled.div`
   position: absolute;
-  bottom: 21px;
+  top: 40%;
 
   label {
-    font-weight: 700;
+    font-weight: 500;
+    font-size: 12px;
   }
 `;
 
@@ -276,25 +301,49 @@ export const TotalPrice = styled(Price)`
   }
 `;
 
-export const BenefitList = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin-bottom: 32px;
-  p {
-    color: ${grayDark};
+export const BenefitList = styled.div`
+  h3 {
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    p {
+      color: ${grayDark};
+    }
+  }
+
+
+  &::before {
+    content: '';
+    border-top: 1px solid ${grayLight};
+    width: 237px;
+    display: block;
+    margin-bottom: 8px;
+    margin-top: 16px;
   }
 `;
 
 export const Benefit = styled.li`
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 2px;
+
+  p {
+    font-size: 12px;
+    color: ${grayDark};
+  }
 
   svg {
     fill: ${blue};
     margin-right: 8px;
   }
 `;
+
 
 export const DowngradeMessage = styled.li`
   display: flex;

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
-  height: ${({ downgradedMessage }) => downgradedMessage ? '660px' : '610px'};
+  height: ${({ downgradedMessage }) => downgradedMessage ? '700px' : '650px'};
   align-items: center;
   border-radius: 8px;
   box-sizing: border-box;
@@ -111,9 +111,9 @@ export const Wrapper = styled.div`
       ? `0px 0px 0px 1.5px ${blue}, 0px 4px 8px rgba(0, 0, 0, 0.04)`
       : `0px 4px 8px rgba(0, 0, 0, 0.04)`};
   border-radius: 3px;
-  height: 450px;
+  height: 500px;
   position: relative;
-  padding: 21px;
+  padding: 32px 21px;
   flex: 1 1 0px;
   margin-right: 12px;
   box-sizing: border-box;
@@ -262,6 +262,7 @@ export const Price = styled.div`
   display: flex;
   align-items: center;
   position: relative;
+  margin-bottom: -4px;
 
   sup {
     font-family: 'Roboto', sans-serif;
@@ -284,7 +285,7 @@ export const Price = styled.div`
     margin-left: 2px;
     margin-right: 2px;
     font-weight: 600;
-    font-size: 26px;
+    font-size: 32px;
   }
 `;
 

--- a/packages/app-shell/src/PlanSelector/style.js
+++ b/packages/app-shell/src/PlanSelector/style.js
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
-  height: 610px;
+  height: ${({ downgradedMessage }) => downgradedMessage ? '660px' : '610px'};
   align-items: center;
   border-radius: 8px;
   box-sizing: border-box;

--- a/packages/app-shell/src/Summary/Summary.stories.js
+++ b/packages/app-shell/src/Summary/Summary.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Summary from './index';
 import response from '../mocks/mock';
+import { UserContext } from '../context/User';
 
 export default {
   title: 'Summary',
@@ -9,7 +10,9 @@ export default {
 
 const Template = (args) => (
   <div style={{ height: '550px' }}>
-    <Summary {...args} />
+    <UserContext.Provider value={response.data.account}>
+      <Summary {...args} />
+    </UserContext.Provider>
   </div>
 );
 

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -176,10 +176,10 @@ const SummaryProvider = ({
       {(user) => {
         return (
           <Summary
-            planOptions={user.currentOrganization.billing.changePlanOptions}
-            trialInfo={user.currentOrganization.billing.subscription?.trial}
+            planOptions={user?.currentOrganization?.billing?.changePlanOptions}
+            trialInfo={user?.currentOrganization?.billing?.subscription?.trial}
             subscriptionEndDate={
-              user.currentOrganization.billing.subscription.periodEnd
+              user?.currentOrganization?.billing?.subscription?.periodEnd
             }
             selectedPlan={selectedPlan}
             fromPlanSelector={fromPlanSelector}

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -154,10 +154,10 @@ const Summary = ({
             </Text>
           </TotalPrice>
           {!selectedPlan.channelsQuantity ? '' : <>{getPriceFooter()}</>}
-          {selectedPlan.planInterval === 'year' && (
+          {selectedPlan.planInterval === 'year' && selectedPlan.planId !== 'free' && (
             <DiscountReminder>
               <Coupon />
-              <p>20% discount</p>
+              <p>{selectedPlan.discountPercentage}% discount</p>
             </DiscountReminder>
           )}
         </Bottom>

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -47,7 +47,7 @@ const Summary = ({
     }
   };
 
-  const getStatus = () => {
+  const getStatus = (fromPlanSelector) => {
     const [currentPlanId, currentPlanInterval] = currentPlanString.split('_');
     const [selectedPlanId, selectedPlanInterval] = selectedPlanString.split(
       '_'
@@ -59,7 +59,7 @@ const Summary = ({
       planStatus = `Currently on ${currentPlan.planName}`;
     } else {
       downgrade = isDowngrading(currentPlanId, selectedPlanId);
-      planStatus = `Changing to ${selectedPlan?.planName}`;
+      planStatus = `${fromPlanSelector ? 'Changing to' : 'Paying for'} ${selectedPlan?.planName}`;
     }
 
     if (isUpgradeIntent) {
@@ -138,9 +138,9 @@ const Summary = ({
       <Body>
         <Text type="h2">Summary</Text>
         <SummaryDetails>
-          {fromPlanSelector ? (
+          {
             <>
-              {getStatus()}
+              {getStatus(fromPlanSelector)}
               <DetailList>
                 {selectedPlan.summary.details.map((detail) => (
                   <Detail key={detail}>
@@ -151,30 +151,7 @@ const Summary = ({
               <Separator />
               <SummaryNote>{getSummaryNote()}</SummaryNote>
             </>
-          ) : (
-            <>
-              <DetailList>
-                <Detail noBulletPoint>
-                  <Checkmark />
-                  <Text type="p">Paying for {selectedPlan.planName}</Text>
-                </Detail>
-              </DetailList>
-              <Separator />
-              <SummaryNote>
-                {trialInfo?.isActive ? (
-                  <Text type="p">
-                    You won't be charged until the end of your trial on{' '}
-                    <b>{formattedTrialEndDate}</b>
-                  </Text>
-                ) : (
-                  <Text type="p">
-                    First payment will take place <span>today</span> and then{' '}
-                    <span>every {intervalInWords}</span>
-                  </Text>
-                )}
-              </SummaryNote>
-            </>
-          )}
+          }
         </SummaryDetails>
 
         <Bottom>
@@ -183,17 +160,6 @@ const Summary = ({
             <Text type="h2" as="p">
               {selectedPlan.totalPrice}
             </Text>
-            <sup
-              aria-label={
-                selectedPlan.summary.intervalUnit === 'mo'
-                  ? 'per month'
-                  : 'per year'
-              }
-            >
-              {selectedPlan.planId === 'free'
-                ? ''
-                : `/${selectedPlan.summary.intervalUnit}`}
-            </sup>
           </TotalPrice>
           {!selectedPlan.channelsQuantity ? '' : <>{getPriceFooter()}</>}
           {selectedPlan.planInterval === 'year' && (

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -77,30 +77,22 @@ const Summary = ({
   };
 
   const getPriceFooter = () => {
-    if (fromPlanSelector) {
-      if (selectedPlan.planId === 'free') {
-        return null;
-      }
-      return (
-        <PriceFooterWrapper>
-          <Text type="p" color="grayDark">
-            Billed {selectedPlan.planInterval}ly in USD
-          </Text>
-          <Text type="p" color="grayDark">
-            {/* this ends up reading: # social channels x base price */}
-            {`Included ${selectedPlan.channelsQuantity} social channel${
-              selectedPlan.channelsQuantity > 1 ? 's' : ''
-            }`}
-          </Text>
-        </PriceFooterWrapper>
-      );
-    } else {
-      return (
-        <Text type="label" color="grayDarker">
-          Includes tax
-        </Text>
-      );
+    if (selectedPlan.planId === 'free') {
+      return null;
     }
+    return (
+      <PriceFooterWrapper>
+        <Text type="p" color="grayDark">
+          Billed {selectedPlan.planInterval}ly in USD
+        </Text>
+        <Text type="p" color="grayDark">
+          {/* this ends up reading: # social channels x base price */}
+          {`Included ${selectedPlan.channelsQuantity} social channel${
+            selectedPlan.channelsQuantity > 1 ? 's' : ''
+          }`}
+        </Text>
+      </PriceFooterWrapper>
+    );
   };
 
   const dateOptions = {

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -87,7 +87,7 @@ const Summary = ({
         </Text>
         <Text type="p" color="grayDark">
           {/* this ends up reading: # social channels x base price */}
-          {`Included ${selectedPlan.channelsQuantity} social channel${
+          {`Includes ${selectedPlan.channelsQuantity} social channel${
             selectedPlan.channelsQuantity > 1 ? 's' : ''
           }`}
         </Text>

--- a/packages/app-shell/src/Summary/index.jsx
+++ b/packages/app-shell/src/Summary/index.jsx
@@ -15,6 +15,9 @@ import {
   BoldPrice,
   Separator,
   SummaryNote,
+  SummaryDetails,
+  Title,
+  PriceFooterWrapper,
 } from './style';
 import { UserContext } from '../context/User';
 
@@ -52,39 +55,23 @@ const Summary = ({
 
     let downgrade;
     let planStatus;
-    let billingIntervalStatus;
     if (currentPlanId === selectedPlanId) {
       planStatus = `Currently on ${currentPlan.planName}`;
     } else {
       downgrade = isDowngrading(currentPlanId, selectedPlanId);
-      planStatus = `${downgrade ? 'Downgrading' : 'Upgrading'} to ${
-        selectedPlan?.planName
-      }`;
+      planStatus = `Changing to ${selectedPlan?.planName}`;
     }
 
     if (isUpgradeIntent) {
-      planStatus = `Upgrade to ${selectedPlan?.planName}`;
+      planStatus = `Change to ${selectedPlan?.planName}`;
       downgrade = false;
-    }
-
-    if (currentPlanInterval !== selectedPlanInterval) {
-      billingIntervalStatus = `Changing to ${selectedPlanInterval}ly billing`;
     }
 
     return (
       <>
-        <Detail noBulletPoint>
-          {downgrade === undefined && <Checkmark />}
-          {downgrade === true && <ArrowDown />}
-          {downgrade === false && <ArrowUp />}
+        <Title>
           <Text type="p">{planStatus}</Text>
-        </Detail>
-        {billingIntervalStatus && (
-          <Detail>
-            <Text type="p">{billingIntervalStatus}</Text>
-          </Detail>
-        )}
-        <Separator />
+        </Title>
       </>
     );
   };
@@ -95,18 +82,17 @@ const Summary = ({
         return null;
       }
       return (
-        <Text type="label" color="grayDarker">
-          {/* this ends up reading: # social channels x base price */}
-          {`${selectedPlan.channelsQuantity} social channel${
-            selectedPlan.channelsQuantity > 1 ? 's' : ''
-          } x `}
-          {
-            <BoldPrice>
-              {selectedPlan.currency}
-              {selectedPlan.summary.intervalBasePrice}
-            </BoldPrice>
-          }
-        </Text>
+        <PriceFooterWrapper>
+          <Text type="p" color="grayDark">
+            Billed {selectedPlan.planInterval}ly in USD
+          </Text>
+          <Text type="p" color="grayDark">
+            {/* this ends up reading: # social channels x base price */}
+            {`Included ${selectedPlan.channelsQuantity} social channel${
+              selectedPlan.channelsQuantity > 1 ? 's' : ''
+            }`}
+          </Text>
+        </PriceFooterWrapper>
       );
     } else {
       return (
@@ -135,14 +121,7 @@ const Summary = ({
     selectedPlan.planInterval === 'month' ? '30 days' : 'year';
 
   const getSummaryNote = () => {
-    if (trialInfo?.isActive) {
-      return (
-        <Text type="p">
-          You won't be charged until the end of your trial on{' '}
-          <span>{formattedTrialEndDate}</span>
-        </Text>
-      );
-    } else if (selectedPlan.planId === 'free' && subscriptionEndDate) {
+    if (selectedPlan.planId === 'free' && subscriptionEndDate) {
       return (
         <Text type="p">
           Changing to Free will occur at the end of your next billing cycle on{' '}
@@ -151,50 +130,52 @@ const Summary = ({
       );
     } else if (selectedPlan.planId === 'free' && !subscriptionEndDate) {
       return <Text type="p">Upgrade your plan at anytime</Text>;
-    } else return <Text type="p">Cancel your plan at anytime</Text>;
+    } else return <Text type="p">First payment due today and then every {selectedPlan.planInterval} until canceled</Text>;
   };
 
   return (
     <SummaryContainer>
       <Body>
         <Text type="h2">Summary</Text>
-        {fromPlanSelector ? (
-          <>
-            <DetailList>
+        <SummaryDetails>
+          {fromPlanSelector ? (
+            <>
               {getStatus()}
-              {selectedPlan.summary.details.map((detail) => (
-                <Detail key={detail}>
-                  <Text type="p">{detail}</Text>
+              <DetailList>
+                {selectedPlan.summary.details.map((detail) => (
+                  <Detail key={detail}>
+                    <Text type="p">{detail}</Text>
+                  </Detail>
+                ))}
+              </DetailList>
+              <Separator />
+              <SummaryNote>{getSummaryNote()}</SummaryNote>
+            </>
+          ) : (
+            <>
+              <DetailList>
+                <Detail noBulletPoint>
+                  <Checkmark />
+                  <Text type="p">Paying for {selectedPlan.planName}</Text>
                 </Detail>
-              ))}
-            </DetailList>
-            <Separator />
-            <SummaryNote>{getSummaryNote()}</SummaryNote>
-          </>
-        ) : (
-          <>
-            <DetailList>
-              <Detail noBulletPoint>
-                <Checkmark />
-                <Text type="p">Paying for {selectedPlan.planName}</Text>
-              </Detail>
-            </DetailList>
-            <Separator />
-            <SummaryNote>
-              {trialInfo?.isActive ? (
-                <Text type="p">
-                  You won't be charged until the end of your trial on{' '}
-                  <b>{formattedTrialEndDate}</b>
-                </Text>
-              ) : (
-                <Text type="p">
-                  First payment will take place <span>today</span> and then{' '}
-                  <span>every {intervalInWords}</span>
-                </Text>
-              )}
-            </SummaryNote>
-          </>
-        )}
+              </DetailList>
+              <Separator />
+              <SummaryNote>
+                {trialInfo?.isActive ? (
+                  <Text type="p">
+                    You won't be charged until the end of your trial on{' '}
+                    <b>{formattedTrialEndDate}</b>
+                  </Text>
+                ) : (
+                  <Text type="p">
+                    First payment will take place <span>today</span> and then{' '}
+                    <span>every {intervalInWords}</span>
+                  </Text>
+                )}
+              </SummaryNote>
+            </>
+          )}
+        </SummaryDetails>
 
         <Bottom>
           <TotalPrice>

--- a/packages/app-shell/src/Summary/style.js
+++ b/packages/app-shell/src/Summary/style.js
@@ -169,7 +169,8 @@ export const Title = styled.div`
     margin-top: 0;
     margin-bottom: 0;
     display: inline-block;
-    font-weight: 600;
+    font-weight: bold;
+    font-size: 14px;
   }
 `;
 

--- a/packages/app-shell/src/Summary/style.js
+++ b/packages/app-shell/src/Summary/style.js
@@ -22,12 +22,13 @@ export const Body = styled.div`
   padding-left: 20px;
   padding-right: 20px;
   position: relative;
-  height: calc(100% - 65px);
+  height: calc(100% - 40px);
 `;
 
 export const Bottom = styled.div`
   position: absolute;
-  bottom: 8px;
+  bottom: 16px;
+  margin-left: 8px;
 
   label {
     display: inline-block;

--- a/packages/app-shell/src/Summary/style.js
+++ b/packages/app-shell/src/Summary/style.js
@@ -1,4 +1,4 @@
-import { blue, grayDark, grayDarker } from '@bufferapp/ui/style/colors';
+import { blue, grayDark, grayDarker, grayLight } from '@bufferapp/ui/style/colors';
 import styled, { css } from 'styled-components';
 
 export const SummaryContainer = styled.div`
@@ -11,6 +11,11 @@ export const SummaryContainer = styled.div`
   padding: 70px 0 24px;
   box-sizing: border-box;
   position: relative;
+
+  h2 {
+    margin-left: 8px;
+    margin-bottom: 16px;
+  }
 `;
 
 export const Body = styled.div`
@@ -34,58 +39,37 @@ export const Bottom = styled.div`
 export const DetailList = styled.ul`
   list-style: none;
   padding: 0;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin: 0;
 
   p {
     margin-top: 0;
     margin-bottom: 0;
     display: inline-block;
-    font-weight: 600;
+    font-weight: 500;
   }
 `;
 
 export const Detail = styled.li`
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
-
-  svg {
-    fill: ${blue};
-    height: 14px;
-    width: 14px;
-    margin-right: 6px;
-    margin-left: -3px;
-  }
-
-  ${(props) =>
-    !props.noBulletPoint &&
-    css`
-      :before {
-        content: '';
-        height: 4px;
-        width: 4px;
-        border-radius: 50%;
-        border: 2px solid ${blue};
-        display: inline-block;
-        margin-right: 8px;
-        box-sizing: content-box;
-      }
-    `}
+  margin-bottom: 6px;
 `;
+
 
 export const DiscountReminder = styled.div`
   display: flex;
+  margin-top: 4px;
+
   p {
     font-family: 'Roboto', sans-serif;
-    font-size: 14px;
+    font-size: 12px;
     font-style: normal;
     font-weight: 700;
     line-height: 16px;
     letter-spacing: 0px;
     color: ${blue};
-    margin-top: 0;
     margin-bottom: 0;
+    margin-top: 0;
   }
   svg {
     fill: ${blue};
@@ -158,5 +142,42 @@ export const SummaryNote = styled.div`
   b {
     font-weight: 600;
     color: ${grayDarker};
+  }
+`;
+
+export const SummaryDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  background: #FFFFFF;
+  border: 1px solid ${grayLight};
+  box-sizing: border-box;
+  border-radius: 4px;
+  padding: 20px 16px;
+
+  ${Detail}, p {
+    font-size: 12px;
+  }
+
+`;
+
+export const Title = styled.div`
+  margin-bottom: 16px;
+
+  p {
+    margin-top: 0;
+    margin-bottom: 0;
+    display: inline-block;
+    font-weight: 600;
+  }
+`;
+
+export const PriceFooterWrapper = styled.div`
+  p {
+    margin-bottom: 0;
+    margin-top: 0;
+    font-size: 12px;
+    font-weight: 500;
   }
 `;

--- a/packages/app-shell/src/graphql/account.js
+++ b/packages/app-shell/src/graphql/account.js
@@ -28,6 +28,7 @@ export const QUERY_ACCOUNT = gql`
         role
         createdAt
         isOneBufferOrganization
+        shouldDisplayInviteCTA
         featureFlips
         billing {
           canAccessAnalytics
@@ -97,6 +98,7 @@ export const QUERY_ACCOUNT = gql`
         role
         createdAt
         isOneBufferOrganization
+        shouldDisplayInviteCTA
         featureFlips
         billing {
           canAccessAnalytics

--- a/packages/app-shell/src/hooks/useUserTracker.js
+++ b/packages/app-shell/src/hooks/useUserTracker.js
@@ -16,7 +16,8 @@ export function identifyUser(user) {
         isPayingBufferUser: traits.isPayingBufferOrganization(user),
         isPayingPublishUser: traits.isPayingPublishOrganization(user),
         isFreePlan: traits.isFreePlan(user),
-        organizationId: user.currentOrganization.id,
+        currentOrganizationId: user.currentOrganization.id,
+        organizationUserRole: traits.organizationUserRole(user),
 
         isOnBufferTrial: traits.isOnBufferTrial(user),
         currentBufferTrialPlan: traits.currentBufferTrialPlan(user),

--- a/packages/app-shell/src/hooks/useUserTracker.test.js
+++ b/packages/app-shell/src/hooks/useUserTracker.test.js
@@ -9,8 +9,9 @@ describe('useUserTracker hooks', () => {
     id: 'fooBar',
     isImpersonation: false,
     currentOrganization: {
-      name: 'fooOrgaName',
       id: 'fooOrg',
+      name: 'fooOrgaName',
+      role: 'admin',
       isOneBufferOrganization: false,
       billing: {
         subscriptions: [
@@ -26,6 +27,7 @@ describe('useUserTracker hooks', () => {
     currentOrganization: {
       id: 'fooOrg',
       name: 'fooOrgaName',
+      role: 'admin',
       isOneBufferOrganization: true,
       billing: {
         subscription: {
@@ -78,7 +80,8 @@ describe('useUserTracker hooks', () => {
           isPayingAnalyzeUser: true,
           isPayingBufferUser: false,
           isPayingPublishUser: true,
-          organizationId: MPUser.currentOrganization.id,
+          currentOrganizationId: MPUser.currentOrganization.id,
+          organizationUserRole: 'admin',
         }))
     });
 
@@ -93,7 +96,8 @@ describe('useUserTracker hooks', () => {
           isOnBufferTrial: false,
           isOnPublishTrial: false,
           isOneBufferEnabled: true,
-          organizationId: OBUser.currentOrganization.id,
+          currentOrganizationId: OBUser.currentOrganization.id,
+          organizationUserRole: 'admin',
         }))
     });
   })

--- a/packages/app-shell/src/hooks/utils/segmentTraitGetters.js
+++ b/packages/app-shell/src/hooks/utils/segmentTraitGetters.js
@@ -162,3 +162,6 @@ export function currentBufferTrialPlan(user) {
   return bufferPlan(user)
 }
 
+export function organizationUserRole({ currentOrganization }) {
+  return currentOrganization?.role || null
+}

--- a/packages/app-shell/src/hooks/utils/segmentTraitGetters.test.js
+++ b/packages/app-shell/src/hooks/utils/segmentTraitGetters.test.js
@@ -12,6 +12,7 @@ import {
   isPayingPublishOrganization,
   isFreePlan,
   trialBillingCycle,
+  organizationUserRole,
 } from './segmentTraitGetters';
 
 describe('Segment Traits Getters', () => {
@@ -22,6 +23,7 @@ describe('Segment Traits Getters', () => {
     currentOrganization: {
       name: 'fooOrgaName',
       id: 'fooOrg',
+      role: 'admin',
       isOneBufferOrganization: false,
       billing: {
         subscriptions: [
@@ -37,6 +39,7 @@ describe('Segment Traits Getters', () => {
     currentOrganization: {
       id: 'fooOrg',
       name: 'fooOrgaName',
+      role: 'member',
       isOneBufferOrganization: true,
       billing: {
         subscription: {
@@ -500,4 +503,20 @@ describe('Segment Traits Getters', () => {
       expect(billingCycle(OBUser)).toEqual('month')
     });
   });
+
+  describe('organizationUserRole', () => {
+    it('should get the role for MP user', () => {
+      expect(organizationUserRole(MPUser)).toBe('admin');
+    });
+
+    it('should get the role for OB user', () => {
+      expect(organizationUserRole(OBUser)).toBe('member');
+    });
+
+    it('should return null if missing role', () => {
+      expect(organizationUserRole({
+        currentOrganization: {}
+      })).toBeNull();
+    });
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,25 @@
 # yarn lockfile v1
 
 
+"@apollo/client@>=2.0.0":
+  version "3.3.19"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.19.tgz#f1172dc9b9d7eae04c8940b047fd3b452ef92d2c"
+  integrity sha512-vzljWLPP0GwocfBhUopzDCUwsiaNTtii1eu8qDybAXqwj4/ZhnIM46c6dNQmnVcJpAIFRIsNCOxM4OlMDySJug==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.12.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.0"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    ts-invariant "^0.7.0"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@apollo/client@^3.3.4", "@apollo/client@latest":
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.11.tgz#125051405e83dc899d471d43b79fd6045d92a802"
@@ -21,7 +40,7 @@
     tslib "^1.10.0"
     zen-observable "^0.8.14"
 
-"@apollo/react-testing@^4.0.0":
+"@apollo/react-testing@>=3.0.0", "@apollo/react-testing@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-4.0.0.tgz#9fd1991584510c2ac051d986547ceccbc9c0a30a"
   integrity sha512-P7Z/flUHpRRZYc3FkIqxZH9XD3FuP2Sgks1IXqGq2Zb7qI0aaTfVeRsLYmZNUcFOh2pTHxs0NXgPnH1VfYOpig==
@@ -1281,6 +1300,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1432,7 +1458,7 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
-"@emotion/styled@^10.0.23":
+"@emotion/styled@^10.0.23", "@emotion/styled@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
   integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
@@ -2720,6 +2746,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.8.3.tgz#8b4eae3d9dd470c022cb9238128db8b1906e7fca"
   integrity sha512-olsVs3lo8qKycPoWAUv4bMyoTGVXsEpLR9XxGk3LJR5Qa92a1Eg/Fj1ATdhwtC/6VMaKtsz1nSAeheD2B2Ru9A==
 
+"@popperjs/core@^2.6.0":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
 "@reach/auto-id@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.6.1.tgz"
@@ -2752,7 +2783,7 @@
     "@reach/observe-rect" "^1.0.3"
     prop-types "^15.7.2"
 
-"@reach/router@^1.3.3":
+"@reach/router@^1.3.3", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
   integrity sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==
@@ -3006,6 +3037,21 @@
     global "^4.3.2"
     regenerator-runtime "^0.13.7"
 
+"@storybook/addons@^6":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.2.9.tgz#b7ba2b9f0e15b852c7d6b57d04fb0a493c57477c"
+  integrity sha512-GnmEKbJwiN1jncN9NSA8CuR1i2XAlasPcl/Zn0jkfV9WitQeczVcJCPw86SGH84AD+tTBCyF2i9UC0KaOV1YBQ==
+  dependencies:
+    "@storybook/api" "6.2.9"
+    "@storybook/channels" "6.2.9"
+    "@storybook/client-logger" "6.2.9"
+    "@storybook/core-events" "6.2.9"
+    "@storybook/router" "6.2.9"
+    "@storybook/theming" "6.2.9"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/api@6.1.19":
   version "6.1.19"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.19.tgz#c816f58d245fef684652a4c43faa2bf8e54c92dd"
@@ -3031,6 +3077,32 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@6.2.9", "@storybook/api@^6":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.2.9.tgz#a9b46569192ad5d8da6435c9d63dc4b0c8463b51"
+  integrity sha512-okkA3HAScE9tGnYBrjTOcgzT+L1lRHNoEh3ZfGgh1u/XNEyHGNkj4grvkd6nX7BzRcYQ/l2VkcKCqmOjUnSkVQ==
+  dependencies:
+    "@reach/router" "^1.3.4"
+    "@storybook/channels" "6.2.9"
+    "@storybook/client-logger" "6.2.9"
+    "@storybook/core-events" "6.2.9"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.2.9"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.2.9"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.12.0"
+    telejson "^5.1.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@6.1.19":
   version "6.1.19"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.19.tgz#af1d51fa50e0716869670a7dfbc9f5db8b2503d2"
@@ -3050,6 +3122,15 @@
   integrity sha512-R3+m0GmPSBCiFFDoVRMjFCNGWvlngHa1I0xEJWry9XigLJYdH+59n/Z+8UIhfIfquyu6U1DJHD6jr8JXThrSLQ==
   dependencies:
     core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/channels@6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.2.9.tgz#a9fd7f25102cbec15fb56f76abf891b7b214e9de"
+  integrity sha512-6dC8Fb2ipNyOQXnUZMDeEUaJGH5DMLzyHlGLhVyDtrO5WR6bO8mQdkzf4+5dSKXgCBNX0BSkssXth4pDjn18rg==
+  dependencies:
+    core-js "^3.8.2"
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
@@ -3085,6 +3166,14 @@
     core-js "^3.0.1"
     global "^4.3.2"
 
+"@storybook/client-logger@6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.2.9.tgz#77c1ea39684ad2a2cf6836051b381fc5b354e132"
+  integrity sha512-IfOQZuvpjh66qBInQCJOb9S0dTGpzZ/Cxlcvokp+PYt95KztaWN3mPm+HaDQCeRsrWNe0Bpm1zuickcJ6dBOXg==
+  dependencies:
+    core-js "^3.8.2"
+    global "^4.4.0"
+
 "@storybook/components@6.1.19":
   version "6.1.19"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.19.tgz#173c7f61fa3a50f674ff0a79520f18ed0485c04e"
@@ -3112,12 +3201,49 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
+"@storybook/components@^6":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.2.9.tgz#7189f9715b05720fe083ae8ad014849f14e98e73"
+  integrity sha512-hnV1MI2aB2g1sJ7NJphpxi7TwrMZQ/tpCJeHnkjmzyC6ez1MXqcBXGrEEdSXzRfAxjQTOEpu6H1mnns0xMP0Ag==
+  dependencies:
+    "@popperjs/core" "^2.6.0"
+    "@storybook/client-logger" "6.2.9"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.2.9"
+    "@types/color-convert" "^2.0.0"
+    "@types/overlayscrollbars" "^1.12.0"
+    "@types/react-syntax-highlighter" "11.0.5"
+    color-convert "^2.0.1"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    markdown-to-jsx "^7.1.0"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.13.1"
+    polished "^4.0.5"
+    prop-types "^15.7.2"
+    react-colorful "^5.0.1"
+    react-popper-tooltip "^3.1.1"
+    react-syntax-highlighter "^13.5.3"
+    react-textarea-autosize "^8.3.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/core-events@6.1.19":
   version "6.1.19"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.19.tgz#d9a9c00721bd67799d2e144ef4eaea8be0ebfc48"
   integrity sha512-E2xBEgpGhSLmB4MWb+fBL9Br0BogmP6EvZn/OLpKuvcMJc1ILLiShZUJKsn+qgwDd96Lk1z4r2+li3DzX3Lf1w==
   dependencies:
     core-js "^3.0.1"
+
+"@storybook/core-events@6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.2.9.tgz#4f12947cd15d1eb3c4109923657c012feef521cd"
+  integrity sha512-xQmbX/oYQK1QsAGN8hriXX5SUKOoTUe3L4dVaVHxJqy7MReRWJpprJmCpbAPJzWS6WCbDFfCM5kVEexHLOzJlQ==
+  dependencies:
+    core-js "^3.8.2"
 
 "@storybook/core@6.1.19":
   version "6.1.19"
@@ -3290,6 +3416,22 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
+"@storybook/router@6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.2.9.tgz#547543031dd8330870bb6b473dcf7e51982e841c"
+  integrity sha512-7Bn1OFoItCl8whXRT8N1qp1Lky7kzXJ3aslWp5E8HcM8rxh4OYXfbaeiyJEJxBTGC5zxgY+tAEXHFjsAviFROg==
+  dependencies:
+    "@reach/router" "^1.3.4"
+    "@storybook/client-logger" "6.2.9"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.20"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    ts-dedent "^2.0.0"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -3330,6 +3472,24 @@
     global "^4.3.2"
     memoizerific "^1.11.3"
     polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
+"@storybook/theming@6.2.9":
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.2.9.tgz#16bf40180861f222c7ed1d80abd5d1e3cb315660"
+  integrity sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.27"
+    "@storybook/client-logger" "6.2.9"
+    core-js "^3.8.2"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.27"
+    global "^4.4.0"
+    memoizerific "^1.11.3"
+    polished "^4.0.5"
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
@@ -3595,6 +3755,18 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
+"@types/color-convert@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/cookie@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz"
@@ -3746,7 +3918,7 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==
 
-"@types/overlayscrollbars@^1.9.0":
+"@types/overlayscrollbars@^1.12.0", "@types/overlayscrollbars@^1.9.0":
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz#98456caceca8ad73bd5bb572632a585074e70764"
   integrity sha512-h/pScHNKi4mb+TrJGDon8Yb06ujFG0mSg12wIO0sWMUF3dQIe2ExRRdNRviaNt9IjxIiOfnRr7FsQAdHwK4sMg==
@@ -3807,6 +3979,13 @@
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
   integrity sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-syntax-highlighter@11.0.5":
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
+  integrity sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==
   dependencies:
     "@types/react" "*"
 
@@ -4237,6 +4416,13 @@
   dependencies:
     tslib "^1.14.1"
 
+"@wry/context@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
+  integrity sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==
+  dependencies:
+    tslib "^2.1.0"
+
 "@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz"
@@ -4251,12 +4437,26 @@
   dependencies:
     tslib "^1.14.1"
 
+"@wry/equality@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.4.0.tgz#474491869a8d0590f4a33fd2a4850a77a0f63408"
+  integrity sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==
+  dependencies:
+    tslib "^2.1.0"
+
 "@wry/trie@^0.2.1":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.2.2.tgz#99f20f0fcbbcda17006069b155c826cbabfc402f"
   integrity sha512-OxqBB39x6MfHaa2HpMiRMfhuUnQTddD32Ko020eBeJXq87ivX6xnSSnzKHVbA21p7iqBASz8n/07b6W5wW1BVQ==
   dependencies:
     tslib "^1.14.1"
+
+"@wry/trie@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.0.tgz#3245e74988c4e3033299e479a1bf004430752463"
+  integrity sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==
+  dependencies:
+    tslib "^2.1.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -6541,6 +6741,11 @@ core-js@^3.0.1, core-js@^3.0.4, core-js@^3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.0.tgz#790b1bb11553a2272b36e2625c7179db345492f8"
   integrity sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==
 
+core-js@^3.8.2:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.13.1.tgz#30303fabd53638892062d8b4e802cac7599e9fb7"
+  integrity sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -7546,7 +7751,7 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-emotion-theming@^10.0.19:
+emotion-theming@^10.0.19, emotion-theming@^10.0.27:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.27.tgz#1887baaec15199862c89b1b984b79806f2b9ab10"
   integrity sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==
@@ -8279,7 +8484,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -9186,6 +9391,11 @@ has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+
+has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
@@ -10249,6 +10459,14 @@ is-regex@^1.0.4, is-regex@^1.1.1:
   dependencies:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
+
+is-regex@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
+  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
+  dependencies:
+    call-bind "^1.0.2"
+    has-symbols "^1.0.2"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -11359,7 +11577,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1:
+"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11520,6 +11738,11 @@ markdown-to-jsx@^6.11.4:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
+
+markdown-to-jsx@^7.1.0:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz#f00bae66c0abe7dd2d274123f84cb6bd2a2c7c6a"
+  integrity sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==
 
 material-colors@^1.2.1:
   version "1.2.6"
@@ -12546,6 +12769,14 @@ optimism@^0.14.0:
     "@wry/context" "^0.5.2"
     "@wry/trie" "^0.2.1"
 
+optimism@^0.16.0:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 optimize-css-assets-webpack-plugin@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz"
@@ -12616,7 +12847,7 @@ osenv@^0.1.4, osenv@^0.1.5:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-overlayscrollbars@^1.10.2:
+overlayscrollbars@^1.10.2, overlayscrollbars@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/overlayscrollbars/-/overlayscrollbars-1.13.1.tgz#0b840a88737f43a946b9d87875a2f9e421d0338a"
   integrity sha512-gIQfzgGgu1wy80EB4/6DaJGHMEGmizq27xHIESrzXq0Y/J0Ay1P3DWk6tuVmEPIZH15zaBlxeEJOqdJKmowHCQ==
@@ -13084,6 +13315,13 @@ polished@^3.4.4:
   integrity sha512-/QgHrNGYwIA4mwxJ/7FSvalUJsm7KNfnXiScVSEG2Xa5qxDeBn4nmdjN2pW00mkM2Tts64ktc47U8F7Ed1BRAA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+polished@^4.0.5:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.3.tgz#7a3abf2972364e7d97770b827eec9a9e64002cfc"
+  integrity sha512-ocPAcVBUOryJEKe0z2KLd1l9EBa1r5mSwlKpExmrLzsnIzJo4axsoU9O2BjOTkDGDT4mZ0WFE5XKTlR3nLnZOA==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
 
 portfinder@^1.0.26:
   version "1.0.28"
@@ -14014,6 +14252,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.10.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.6.0, qs@^6.9.4:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
@@ -14151,6 +14396,11 @@ react-color@^2.17.0:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-colorful@^5.0.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.2.2.tgz#0a69d0648db47e51359d343854d83d250a742243"
+  integrity sha512-Xdb1Rl6lZ5SMdNBH59eE0lGqR1g2LVD8IgPlw0WeMDrOC65lYI8fgMEwj/0dDpVRVMh5qp73ciISDst/t2O2iQ==
 
 react-dev-utils@^10.0.0:
   version "10.2.1"
@@ -14424,7 +14674,7 @@ react-sizeme@^2.6.7:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
-react-syntax-highlighter@^13.5.0:
+react-syntax-highlighter@^13.5.0, react-syntax-highlighter@^13.5.3:
   version "13.5.3"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz#9712850f883a3e19eb858cf93fad7bb357eea9c6"
   integrity sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==
@@ -14439,6 +14689,15 @@ react-textarea-autosize@^8.1.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.1.tgz#b942a934cc660ecfc645717d1fb84344b69dcb15"
   integrity sha512-Vk02C3RWKLjx1wSwcVuPwfTuyGIemBB2MjDi01OnBYxKWSJFA/O7IOzr9FrO8AuRlkupk4X6Kjew2mYyEDXi0A==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    use-composed-ref "^1.0.0"
+    use-latest "^1.0.0"
+
+react-textarea-autosize@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.2.tgz#4f9374d357b0a6f6469956726722549124a1b2db"
+  integrity sha512-JrMWVgQSaExQByP3ggI1eA8zF4mF0+ddVuX7acUeK2V7bmrpjVOY72vmLz2IXFJSAXoY3D80nEzrn0GWajWK3Q==
   dependencies:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
@@ -15812,10 +16071,22 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-store2@^2.7.1:
+store2@^2.12.0, store2@^2.7.1:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
+
+storybook-addon-apollo-client@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/storybook-addon-apollo-client/-/storybook-addon-apollo-client-4.0.8.tgz#9a1e2938594280d72815bc96bbed52b24e067ee0"
+  integrity sha512-EmsQkhAFPNEv2jDg8Dzlz7MpyyRzjyEfTH5Ckw8HP3G52JWZQHiJE+Dl5WDiszlKnPKo/ZwOCcQ336t4XCm6GQ==
+  dependencies:
+    "@storybook/addons" "^6"
+    "@storybook/api" "^6"
+    "@storybook/components" "^6"
+  optionalDependencies:
+    "@apollo/client" ">=2.0.0"
+    "@apollo/react-testing" ">=3.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -16274,6 +16545,20 @@ telejson@^5.0.2:
     lodash "^4.17.20"
     memoizerific "^1.11.3"
 
+telejson@^5.1.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/telejson/-/telejson-5.3.3.tgz#fa8ca84543e336576d8734123876a9f02bf41d2e"
+  integrity sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==
+  dependencies:
+    "@types/is-function" "^1.0.0"
+    global "^4.4.0"
+    is-function "^1.0.2"
+    is-regex "^1.1.2"
+    is-symbol "^1.0.3"
+    isobject "^4.0.0"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -16635,6 +16920,13 @@ ts-invariant@^0.6.0:
     "@ungap/global-this" "^0.4.2"
     tslib "^1.9.3"
 
+ts-invariant@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.7.3.tgz#13aae22a4a165393aaf5cecdee45ef4128d358b8"
+  integrity sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz"
@@ -16659,6 +16951,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.20.0"


### PR DESCRIPTION
- [[GROW-18](https://buffer.atlassian.net/browse/GROW-18)] default plan selector to annual pricing when upgrading
- track `organizationUserRole`
- [[GROW-53](https://buffer.atlassian.net/browse/GROW-53)] Remove the "You will be charged after trial" message from the plan selector
- [[GROW-12](https://buffer.atlassian.net/browse/GROW-12)] Plan selector tweaks, depends on https://github.com/bufferapp/core-authentication-service/pull/1008
![image](https://user-images.githubusercontent.com/992920/119865152-3c5af100-bed0-11eb-9988-b9ddda5fdd9c.png)
![image](https://user-images.githubusercontent.com/992920/119589713-3f4aca00-bd88-11eb-8554-7ebb5d1aafd1.png)
- [[GROW-8](https://buffer.atlassian.net/browse/GROW-8)] Optimize UX for Invoice access in the Plan Selector
- [[GROW-23](https://buffer.atlassian.net/browse/GROW-23)] Persistent CTAs in top nav for OB/MP
- [[GROW-14](https://buffer.atlassian.net/browse/GROW-14)] Add Invite your Team CTA to Appshell, depends on https://github.com/bufferapp/core-authentication-service/pull/1006/