### PR TITLE
fix start trial menu CTA

### DIFF
--- a/packages/app-shell/src/NavBar/index.jsx
+++ b/packages/app-shell/src/NavBar/index.jsx
@@ -380,7 +380,7 @@ const NavBar = React.memo((props) => {
                   colors: { title: 'blue', iconHover: 'blueDaker' },
                   hasDivider: true,
                   onItemClick: () => {
-                    openModal(MODALS.planSelector, {
+                    openModal(MODALS.startTrial, {
                       cta: 'startFreeTrial',
                       ctaButton: 'startFreeTrial',
                       isUpgradeIntent: true,


### PR DESCRIPTION
This fixes the `start free trial` CTA in the dropdown menu, if was opening the plan selector instead of the start trial modal