### PR TITLE
Add trial expired modal [GROW-5]

### DIFF
--- a/packages/app-shell/src/Modal/index.jsx
+++ b/packages/app-shell/src/Modal/index.jsx
@@ -1,10 +1,15 @@
 import React, { useState, useEffect } from 'react';
+
+import { getCookie } from '../utils/cookies'
 import { MODALS } from '../hooks/useModal';
+import { useUser } from '../context/User';
 import SimpleModal from '@bufferapp/ui/SimpleModal';
 import PaymentMethod from '../PaymentMethod';
 import PlanSelector from '../PlanSelector';
 import StartTrial from '../StartTrial';
 import Confirmation from '../Confirmation';
+import TrialExpired from '../TrialExpired';
+
 
 const ModalContent = ({ modal }) => {
   switch (modal) {
@@ -16,22 +21,24 @@ const ModalContent = ({ modal }) => {
       return <Confirmation />;
     case MODALS.startTrial:
       return <StartTrial />;
+    case MODALS.trialExpired:
+      return <TrialExpired />;
     default:
       return null;
   }
 };
 
-const Modal = ({ modal, openModal, isAwaitingUserAction }) => {
+const Modal = ({ modal, openModal }) => {
   const [hasModal, setHasModal] = useState(!!modal);
+  const user = useUser()
 
   useEffect(() => {
-    if (isAwaitingUserAction) {
-      openModal(MODALS.planSelector, {
-        cta: 'awaitingUserAction',
-        isUpgradeIntent: false,
-      });
+    const hasDismissedTrialModal = getCookie({ key: 'trialOverDismissed' })
+    const isAwaitingUserAction = user?.currentOrganization?.billing?.subscription?.trial?.isAwaitingUserAction || false;
+    if (!hasDismissedTrialModal && isAwaitingUserAction) {
+      openModal(MODALS.trialExpired)
     }
-  }, [isAwaitingUserAction]);
+  }, []);
 
   useEffect(() => {
     setHasModal(!!modal);

--- a/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
+++ b/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Modal as TrialExpired } from './index';
+import response from '../mocks/mock';
+
+export default {
+  title: 'Trial Expired Modal',
+  component: TrialExpired,
+};
+
+const Template = (args) => <TrialExpired {...args} />;
+
+export const OneExample = Template.bind({});
+OneExample.args = {
+  plan: response.data.account.currentOrganization.billing.changePlanOptions[0],
+  closeModal: () => {},
+};

--- a/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
+++ b/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
@@ -1,16 +1,21 @@
-import React from 'react';
-import { Modal as TrialExpired } from './index';
-import response from '../mocks/mock';
+import React from 'react'
+import { Modal as TrialExpired } from './index'
+import { UserContext } from '../context/User'
+import response from '../mocks/trialExpiredMock'
 
 export default {
   title: 'Trial Expired Modal',
   component: TrialExpired,
-};
+}
 
-const Template = (args) => <TrialExpired {...args} />;
+const Template = (args) => (
+  <UserContext.Provider value={response.data.account}>
+    <TrialExpired {...args} />
+  </UserContext.Provider>
+)
 
-export const OneExample = Template.bind({});
+export const OneExample = Template.bind({})
 OneExample.args = {
-  plan: response.data.account.currentOrganization.billing.changePlanOptions[0],
+  user: response.data.account,
   closeModal: () => {},
-};
+}

--- a/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
+++ b/packages/app-shell/src/TrialExpired/TrialExpired.stories.jsx
@@ -17,5 +17,6 @@ const Template = (args) => (
 export const OneExample = Template.bind({})
 OneExample.args = {
   user: response.data.account,
-  closeModal: () => {},
+  onDismiss: () => { console.log('dimiss') },
+  onUpgrade: () => { console.log('upgrade') },
 }

--- a/packages/app-shell/src/TrialExpired/index.jsx
+++ b/packages/app-shell/src/TrialExpired/index.jsx
@@ -1,0 +1,108 @@
+import React, { useContext, useEffect } from 'react';
+import styled from 'styled-components';
+import Text from '@bufferapp/ui/Text';
+import Button from '@bufferapp/ui/Button';
+
+import { black } from '@bufferapp/ui/style/colors';
+import { useTrackPageViewed } from '../hooks/useSegmentTracking';
+import { UserContext } from '../context/User';
+import { ModalContext } from '../context/Modal';
+
+const ScreenContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 800px;
+  height: ${({ planId }) => planId === 'team' ? '446px' : '376px'};
+  box-sizing: border-box;
+  background-repeat: no-repeat;
+  background-position-x: right;
+  background-position-y: bottom;
+  background-image: url(${(props) => props.imageUrl});
+  background-size: 445px;
+  padding: 24px;
+
+  p,
+  h1 {
+    color: ${black};
+  }
+
+  h1 {
+    max-width: 324px;
+    margin-top: 22px;
+    margin-bottom: 22px;
+  }
+
+  p {
+    margin-top: 0px;
+    max-width: 282px;
+  }
+
+  p:last-child {
+    font-style: italic;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  width: fit-content;
+  margin-top: 32px;
+  margin-bottom: 32px;
+`;
+
+export const Modal = ({
+  plan,
+  closeModal,
+}) => {
+  const planName = plan ? plan.planName : null;
+
+  const currentUser = useContext(UserContext);
+  const { data } = useContext(ModalContext);
+  useEffect(() => {
+    // useTrackPageViewed({
+    //   payload: {
+    //     name: 'trial',
+    //     title: 'planSelector',
+    //   },
+    //   user: currentUser,
+    // });
+  }, []);
+
+  const imageUrl = 'https://buffer-ui.s3.amazonaws.com/Confirmation+Illustration.png';
+  const description = `Your trial is over and you are back to free features. Upgrade to get the power restored.`;
+
+  return (
+    <ScreenContainer planId={plan.planId} imageUrl={imageUrl}>
+      <Text type="h1">Your trial has expired</Text>
+      <Text type="p">{description}</Text>
+      <ButtonContainer>
+        <Button
+          type="primary"
+          onClick={() => {
+            closeModal();
+          }}
+          label="Upgrade"
+        />
+      </ButtonContainer>
+    </ScreenContainer>
+  );
+};
+
+const TrialExpired = () => {
+  return (
+    <UserContext.Consumer>
+      {(user) => (
+        <ModalContext.Consumer>
+          {({ openModal, data }) => (
+            <Modal
+              plan={data.plan}
+              closeModal={() => {
+                openModal(null);
+              }}
+            />
+          )}
+        </ModalContext.Consumer>
+      )}
+    </UserContext.Consumer>
+  );
+};
+
+export default TrialExpired;

--- a/packages/app-shell/src/TrialExpired/index.jsx
+++ b/packages/app-shell/src/TrialExpired/index.jsx
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
 
-import { black } from '@bufferapp/ui/style/colors';
+import { black, blue } from '@bufferapp/ui/style/colors';
 import { useTrackPageViewed } from '../hooks/useSegmentTracking';
 import { UserContext } from '../context/User';
 import { ModalContext } from '../context/Modal';
+import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
+
 
 const ScreenContainer = styled.div`
   display: flex;
@@ -36,16 +38,35 @@ const ScreenContainer = styled.div`
     margin-top: 0px;
     max-width: 282px;
   }
-
-  p:last-child {
-    font-style: italic;
-  }
 `;
 
 const ButtonContainer = styled.div`
   width: fit-content;
   margin-top: 32px;
   margin-bottom: 32px;
+
+  > div:first-child {
+    margin-right: 8px;
+  }
+`;
+
+const Details = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  svg {
+    color: ${blue};
+    margin-right: 4px;
+  }
+
+  li {
+    display: flex;
+
+    p {
+      margin-bottom: 8px;
+    }
+  }
 `;
 
 export const Modal = ({
@@ -65,11 +86,19 @@ export const Modal = ({
 
   const imageUrl = 'https://buffer-ui.s3.amazonaws.com/Confirmation+Illustration.png';
   const description = `Your trial is over and you are back to free features. Upgrade to get the power restored.`;
+  const planId = user?.currentOrganization?.billing?.subscription?.plan?.id
+  const planDetails = user?.currentOrganization?.billing?.changePlanOptions.find(o => o.planId === planId)?.summary.details
 
   return (
     <ScreenContainer imageUrl={imageUrl}>
       <Text type="h1">Your trial has expired</Text>
       <Text type="p">{description}</Text>
+      <Details>
+        {planDetails.map(detail => (<li>
+          <CheckmarkIcon size="medium" />
+          <Text type="p">{detail}</Text>
+        </li>))}
+      </Details>
       <ButtonContainer>
         <Button
           type="primary"
@@ -78,7 +107,15 @@ export const Modal = ({
           }}
           label="Upgrade"
         />
-      </ButtonContainer>
+      <Button
+        type="secondary"
+        onClick={() => {
+          //TODO set cookie
+          closeModal();
+        }}
+        label="No Thanks"
+      />
+    </ButtonContainer>
     </ScreenContainer>
   );
 };

--- a/packages/app-shell/src/TrialExpired/index.jsx
+++ b/packages/app-shell/src/TrialExpired/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
@@ -49,28 +49,25 @@ const ButtonContainer = styled.div`
 `;
 
 export const Modal = ({
-  plan,
+  user,
   closeModal,
 }) => {
-  const planName = plan ? plan.planName : null;
 
-  const currentUser = useContext(UserContext);
-  const { data } = useContext(ModalContext);
   useEffect(() => {
-    // useTrackPageViewed({
-    //   payload: {
-    //     name: 'trial',
-    //     title: 'planSelector',
-    //   },
-    //   user: currentUser,
-    // });
+    useTrackPageViewed({
+      payload: {
+        name: 'trial',
+        title: 'trial expired modal',
+      },
+      user
+    });
   }, []);
 
   const imageUrl = 'https://buffer-ui.s3.amazonaws.com/Confirmation+Illustration.png';
   const description = `Your trial is over and you are back to free features. Upgrade to get the power restored.`;
 
   return (
-    <ScreenContainer planId={plan.planId} imageUrl={imageUrl}>
+    <ScreenContainer imageUrl={imageUrl}>
       <Text type="h1">Your trial has expired</Text>
       <Text type="p">{description}</Text>
       <ButtonContainer>
@@ -91,9 +88,9 @@ const TrialExpired = () => {
     <UserContext.Consumer>
       {(user) => (
         <ModalContext.Consumer>
-          {({ openModal, data }) => (
+          {({ openModal }) => (
             <Modal
-              plan={data.plan}
+              user={user}
               closeModal={() => {
                 openModal(null);
               }}
@@ -102,7 +99,7 @@ const TrialExpired = () => {
         </ModalContext.Consumer>
       )}
     </UserContext.Consumer>
-  );
+  )
 };
 
 export default TrialExpired;

--- a/packages/app-shell/src/hooks/useModal.js
+++ b/packages/app-shell/src/hooks/useModal.js
@@ -7,6 +7,7 @@ export const MODALS = {
   planSelector: 'planSelector',
   success: 'success',
   startTrial: 'startTrial',
+  trialExpired: 'trialExpired',
 }
 
 export const EVENT_KEY = 'appshell__modal_event'
@@ -24,15 +25,6 @@ function useModal() {
   const [modal, setModal] = useState(null)
   const [data, setData] = useState(null)
 
-  useEffect(() => {
-    const { hash } = window.location
-    const matchingModal = Object.keys(MODALS).find(k => k === hash.replace('#', ''))
-    if (matchingModal) {
-      window.location.hash = '';
-      setModal(matchingModal)
-    }
-  }, [])
-
   const openModal = useCallback((modalKey, modalData = null) => {
     const matchingModal = Object.keys(MODALS).find(k => k === modalKey)
     if (matchingModal) {
@@ -45,6 +37,17 @@ function useModal() {
     }
   }, [])
 
+  // Open Modal from url matching
+  useEffect(() => {
+    const { hash } = window.location
+    const matchingModal = Object.keys(MODALS).find(k => k === hash.replace('#', ''))
+    if (matchingModal) {
+      window.location.hash = '';
+      setModal(matchingModal)
+    }
+  }, [])
+
+  // Open modal from events
   useEffect(() => {
     window.addEventListener(EVENT_KEY, (e) => {
       const { modal:modalKey, data:modalData } = e.detail

--- a/packages/app-shell/src/index.jsx
+++ b/packages/app-shell/src/index.jsx
@@ -109,12 +109,6 @@ export const Navigator = ({
         )}
         <Modal
           {...modal}
-          isAwaitingUserAction={
-            data
-              ? data.account.currentOrganization.billing.subscription?.trial
-                  ?.isAwaitingUserAction
-              : null
-          }
         />
       </ModalContext.Provider>
     </UserContext.Provider>

--- a/packages/app-shell/src/mocks/trialExpiredMock.js
+++ b/packages/app-shell/src/mocks/trialExpiredMock.js
@@ -15,7 +15,12 @@ export default {
             trial: {
               isActive: false,
               remainingDays: 0,
+              isAwaitingUserAction: true,
             },
+            plan: {
+              id: 'essentials',
+              name: 'Essentials',
+            }
           },
           changePlanOptions: [
             {
@@ -57,7 +62,11 @@ export default {
               discountNote: '',
               priceNote: 'Price per social channel',
               summary: {
-                details: ['Add social channels anytime', 'Cancel at anytime'],
+                details: [
+                  'Unlimited scheduled posts',
+                  'Unlimited social channels',
+                  'One user',
+                ],
                 warning:
                   'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
                 intervalBasePrice: 5,

--- a/packages/app-shell/src/mocks/trialExpiredMock.js
+++ b/packages/app-shell/src/mocks/trialExpiredMock.js
@@ -1,0 +1,176 @@
+export default {
+  data: {
+    account: {
+      currentOrganization: {
+        id: '600750cd1d3b3b14cc552adf',
+        canEdit: true,
+        billing: {
+          paymentDetails: {
+            hasPaymentDetails: true,
+          },
+          isFree: false,
+          canAccessAnalytics: true,
+          canStartTrial: false,
+          subscription: {
+            trial: {
+              isActive: false,
+              remainingDays: 0,
+            },
+          },
+          changePlanOptions: [
+            {
+              planId: 'free',
+              planName: 'Free',
+              planInterval: 'month',
+              channelsQuantity: 1,
+              description: 'Commit to a social media strategy before you pay.',
+              isCurrentPlan: false,
+              highlights: ['3 social channels', '10 scheduled posts'],
+              currency: '$',
+              basePrice: 0,
+              totalPrice: 0,
+              discountPercentage: 0,
+              discountNote: '',
+              priceNote: 'Enjoy for free',
+              summary: {
+                details: ['Upgrade anytime'],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 0,
+                intervalUnit: 'mo',
+              },
+              isRecommended: false,
+            },
+            {
+              planId: 'essentials',
+              planName: 'Essentials',
+              planInterval: 'month',
+              channelsQuantity: 1,
+              description:
+                'Grow your business with advanced features and unlimited usage.',
+              isCurrentPlan: false,
+              highlights: ['Unlimited usage', 'Advanced IG features'],
+              currency: '$',
+              basePrice: 5,
+              totalPrice: 5,
+              discountPercentage: 0,
+              discountNote: '',
+              priceNote: 'Price per social channel',
+              summary: {
+                details: ['Add social channels anytime', 'Cancel at anytime'],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 5,
+                intervalUnit: 'mo',
+              },
+              isRecommended: false,
+            },
+            {
+              planId: 'team',
+              planName: 'Team',
+              planInterval: 'month',
+              channelsQuantity: 1,
+              description:
+                'Collaborate with your team in one place and create shareable reports.',
+              isCurrentPlan: false,
+              highlights: ['Unlimited usage', 'Unlimited users'],
+              currency: '$',
+              basePrice: 10,
+              totalPrice: 10,
+              discountPercentage: 0,
+              discountNote: '',
+              priceNote: 'Price per social channel',
+              summary: {
+                details: [
+                  'Add users anytime',
+                  'Add social channels anytime',
+                  'Cancel at anytime',
+                ],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 10,
+                intervalUnit: 'mo',
+              },
+              isRecommended: false,
+            },
+            {
+              planId: 'free',
+              planName: 'Free',
+              planInterval: 'year',
+              channelsQuantity: 1,
+              description: 'Commit to a social media strategy before you pay.',
+              isCurrentPlan: false,
+              highlights: ['3 social channels', '10 scheduled posts'],
+              currency: '$',
+              basePrice: 0,
+              totalPrice: 0,
+              discountPercentage: 0,
+              discountNote: '0% Discount',
+              priceNote: 'Enjoy for free',
+              summary: {
+                details: ['Upgrade anytime'],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 0,
+                intervalUnit: 'yr',
+              },
+              isRecommended: false,
+            },
+            {
+              planId: 'essentials',
+              planName: 'Essentials',
+              planInterval: 'year',
+              channelsQuantity: 1,
+              description:
+                'Grow your business with advanced features and unlimited usage.',
+              isCurrentPlan: false,
+              highlights: ['Unlimited usage', 'Advanced IG features'],
+              currency: '$',
+              basePrice: 4,
+              totalPrice: 48,
+              discountPercentage: 20,
+              discountNote: '20% Discount',
+              priceNote: 'Price per social channel',
+              summary: {
+                details: ['Add social channels anytime', 'Cancel at anytime'],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 48,
+                intervalUnit: 'yr',
+              },
+              isRecommended: false,
+            },
+            {
+              planId: 'team',
+              planName: 'Team',
+              planInterval: 'year',
+              channelsQuantity: 1,
+              description:
+                'Collaborate with your team in one place and create shareable reports.',
+              isCurrentPlan: true,
+              highlights: ['Unlimited usage', 'Unlimited users'],
+              currency: '$',
+              basePrice: 8,
+              totalPrice: 96,
+              discountPercentage: 20,
+              discountNote: '20% Discount',
+              priceNote: 'Price per social channel',
+              summary: {
+                details: [
+                  'Add users anytime',
+                  'Add social channels anytime',
+                  'Cancel at anytime',
+                ],
+                warning:
+                  'By downgrading, aspects of your account will be frozen to meet with plan quotas. Nothings will be lost.',
+                intervalBasePrice: 96,
+                intervalUnit: 'yr',
+              },
+              isRecommended: true,
+            },
+          ],
+        },
+      },
+    },
+  },
+};

--- a/packages/app-shell/src/utils/cookies.js
+++ b/packages/app-shell/src/utils/cookies.js
@@ -1,0 +1,17 @@
+export const DATES = {
+  inMonthsFromNow(months) {
+    const now = new Date()
+    return new Date(now.setMonth(now.getMonth() + months));
+  }
+}
+
+export function setCookie({ key, value, expires }) {
+  document.cookie = `appshell_${key}=${value};path=/;expires=${expires.toUTCString()}`
+}
+
+export function getCookie({ key }) {
+  const regex = new RegExp(`appshell_${key}=(\\w+)`, "g")
+  const cookie = document.cookie.match(regex) || [null]
+  const [k, value] = cookie[0]?.split("=") || [null, false] // eslint-disable-line no-unused-vars
+  return value
+}

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -25,6 +25,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <style type="text/css">
+      body {
+        font-family: 'Roboto';
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-size: 16px;
+      }
+
       #navigator {
         min-height: 57px;
       }

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -24,11 +24,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800" rel="stylesheet">
     <style type="text/css">
       body {
-        font-family: 'Roboto';
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
+        font-family: Roboto, sans-serif !important;
         font-size: 16px;
       }
 


### PR DESCRIPTION
To show the trial expired modal if a user terminated is trial [[GROW-5]](https://buffer.atlassian.net/browse/GROW-5).
Once the modal is dismissed it won't be visible, on the same browser, for 2 months.

![image](https://user-images.githubusercontent.com/992920/124686339-cad77080-de87-11eb-8723-a5798e111d00.png)


### Note:
If you want to test this without setting up the user you can show the modal typing `window.appshell.actions.openModal(window.appshell.MODALS.trialExpired)` in the  browser dev console.

[GROW-5]: https://buffer.atlassian.net/browse/GROW-5