### PR TITLE
 expose setCurrentOrganization action

### DIFF
--- a/packages/app-shell/src/common/hooks/useModal.js
+++ b/packages/app-shell/src/common/hooks/useModal.js
@@ -48,12 +48,18 @@ function useModal() {
   }, [])
 
   // Open modal from events
+  function handleOpenModal({ detail }) {
+    const { modal:modalKey, data:modalData } = detail
+    openModal(modalKey, modalData)
+  }
+
   useEffect(() => {
-    window.addEventListener(EVENT_KEY, (e) => {
-      const { modal:modalKey, data:modalData } = e.detail
-      openModal(modalKey, modalData)
-    })
-  })
+    window.addEventListener(EVENT_KEY, handleOpenModal)
+
+    return function cleanup() {
+      window.removeEventListener(EVENT_KEY, handleOpenModal)
+    }
+  }, [])
 
   return {
     data,

--- a/packages/app-shell/src/exports/navigator.js
+++ b/packages/app-shell/src/exports/navigator.js
@@ -1,5 +1,5 @@
 import { MODALS, ACTIONS as MODAL_ACTIONS, EVENT_KEY as MODAL_EVENT_KEY } from '../common/hooks/useModal';
-import { EVENT_KEY as ORGANIZATION_EVENT_KEY } from '../common/hooks/useOrgSwitcher';
+import { EVENT_KEY as ORGANIZATION_EVENT_KEY, ACTIONS as ORGANIZATION_ACTIONS } from '../common/hooks/useOrgSwitcher';
 import render from './Navigator';
 
 window.appshell = {
@@ -9,6 +9,7 @@ window.appshell = {
   },
   actions: {
     ...MODAL_ACTIONS,
+    ...ORGANIZATION_ACTIONS,
   },
   MODALS,
 }


### PR DESCRIPTION
This expose the `setCurrentOrganization` action so that product apps can trigger the organization change outside of the Navigator.
This is needed to allow Publishing to change the org based on the url.