### PR TITLE
fix trial expired modal

### DIFF
--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -34,11 +34,11 @@ const Modal = ({ modal, openModal }) => {
 
   useEffect(() => {
     const hasDismissedTrialModal = getCookie({ key: 'trialOverDismissed' })
-    const isAwaitingUserAction = user?.currentOrganization?.billing?.subscription?.trial?.isAwaitingUserAction || false;
+    const isAwaitingUserAction = true;
     if (!hasDismissedTrialModal && isAwaitingUserAction) {
       openModal(MODALS.trialExpired)
     }
-  }, []);
+  }, [user.loading]);
 
   useEffect(() => {
     setHasModal(!!modal);


### PR DESCRIPTION
Make sure the user data has been load before processing the trial expired modal conditions