### PR TITLE
always set cookies for Trial Expired Modal

### DIFF
--- a/packages/app-shell/src/common/utils/cookies.js
+++ b/packages/app-shell/src/common/utils/cookies.js
@@ -6,7 +6,7 @@ export const DATES = {
 }
 
 export function setCookie({ key, value, expires }) {
-  document.cookie = `appshell_${key}=${value};path=/;expires=${expires.toUTCString()}`
+  document.cookie = `appshell_${key}=${value};domain=.buffer.com;path=/;expires=${expires.toUTCString()}`
 }
 
 export function getCookie({ key }) {

--- a/packages/app-shell/src/components/Modal/modals/TrialExpired/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/TrialExpired/index.jsx
@@ -124,6 +124,14 @@ export const Modal = ({
   );
 };
 
+function setTrialDismissedCookies() {
+  setCookie({
+    key: 'trialOverDismissed',
+    value: true,
+    expires: DATES.inMonthsFromNow(2),
+  })
+}
+
 const TrialExpired = () => {
   return (
     <UserContext.Consumer>
@@ -133,14 +141,11 @@ const TrialExpired = () => {
             <Modal
               user={user}
               onDismiss={() => {
-                setCookie({
-                  key: 'trialOverDismissed',
-                  value: true,
-                  expires: DATES.inMonthsFromNow(2),
-                })
+                setTrialDismissedCookies()
                 openModal(null);
               }}
               onUpgrade={() => {
+                setTrialDismissedCookies()
                 openModal(MODALS.planSelector, {
                   cta: 'ugradePlan',
                   ctaButton: 'ugradePlan',


### PR DESCRIPTION
store trial expired modal dismiss on both CTAs, and set a root domain  cookie