### PR TITLE
Updated Upgrade CTA URL [GROW-172]

### DIFF
--- a/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
@@ -71,7 +71,7 @@ const UpgradeCTA = () => {
                               });
                             }
                           } else {
-                            window.location = `https://account.${envModifier ? envModifier : ''}buffer.com/billing`;
+                            window.location = `https://publish.${envModifier ? envModifier : ''}buffer.com/plans`;
                           }
                         }}
                         icon={<FlashIcon />}


### PR DESCRIPTION
Updated the Upgrade CTA URL to https://publish.buffer.com/plans for free non trial users. 

[[GROW-172]](https://buffer.atlassian.net/browse/GROW-172)


[GROW-172]: https://buffer.atlassian.net/browse/GROW-172