### PR TITLE
Update README, and add watch-production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "app": "lerna exec --scope app -- yarn watch",
+    "app-production": "lerna exec --scope app -- yarn watch-production",
     "app-shell": "lerna exec --scope @bufferapp/app-shell -- yarn watch",
     "build": "npm-run-all --serial build:app build:app-shell",
     "build:app": "lerna exec --scope app -- yarn build",
@@ -20,6 +21,7 @@
     "serve": "serve -l 3000 ./packages/app/build",
     "test": "jest",
     "test:watch": "jest --watch",
-    "watch": "npm-run-all --parallel app app-shell"
+    "watch": "npm-run-all --parallel app app-shell",
+    "watch-production": "npm-run-all --parallel app-production app-shell"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,8 @@
     "build": "REACT_APP_API_GATEWAY_URL='https://graph.buffer.com' REACT_APP_PATH='/static/js/' REACT_APP_FILE_NAME='navigator.js' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "watch": "HTTPS=true HOST='0.0.0.0' REACT_APP_API_GATEWAY_URL='https://graph.local.buffer.com' REACT_APP_PATH='https://appshell.local.buffer.com:8085/' REACT_APP_FILE_NAME='main.js' react-scripts start"
+    "watch": "HTTPS=true HOST='0.0.0.0' REACT_APP_API_GATEWAY_URL='https://graph.local.buffer.com' REACT_APP_PATH='https://appshell.local.buffer.com:8085/' REACT_APP_FILE_NAME='main.js' react-scripts start",
+    "watch-production": "HTTPS=true HOST='0.0.0.0' REACT_APP_API_GATEWAY_URL='https://graph.buffer.com' REACT_APP_PATH='https://appshell.local.buffer.com:8085/' REACT_APP_FILE_NAME='main.js' react-scripts start"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This updates the readme, and adds `yarn watch-procution` to run the AppShell in dev mode against production APIs Gateway.