### PR TITLE
GROW-190 properly pass CTAs for upgrade and trial start

### DIFF
--- a/packages/app-shell/src/common/graphql/billing.js
+++ b/packages/app-shell/src/common/graphql/billing.js
@@ -54,11 +54,13 @@ export const START_TRIAL = gql`
     $organizationId:String,
     $plan:OBPlanId,
     $interval:BillingInterval
+    $attribution:AttributionInput
   ) {
     billingStartTrial(
       organizationId:$organizationId, 
       plan:$plan, 
-      interval:$interval
+      interval:$interval,
+      attribution:$attribution
     )
     {
       ... on BillingResponse { success }

--- a/packages/app-shell/src/common/graphql/billing.js
+++ b/packages/app-shell/src/common/graphql/billing.js
@@ -35,12 +35,14 @@ export const UPDATE_SUBSCRIPTION_PLAN = gql`
   mutation updatePlan(
     $organizationId: String,
     $plan: OBPlanId,
-    $interval: BillingInterval
+    $interval: BillingInterval,
+    $attribution:AttributionInput
   ) {
     billingUpdateSubscriptionPlan(
       organizationId: $organizationId,
       plan: $plan,
-      interval: $interval
+      interval: $interval,
+      attribution:$attribution
     )
     {
       ... on BillingResponse { success }
@@ -53,11 +55,11 @@ export const START_TRIAL = gql`
   mutation startTrial(
     $organizationId:String,
     $plan:OBPlanId,
-    $interval:BillingInterval
+    $interval:BillingInterval,
     $attribution:AttributionInput
   ) {
     billingStartTrial(
-      organizationId:$organizationId, 
+      organizationId:$organizationId,
       plan:$plan, 
       interval:$interval,
       attribution:$attribution

--- a/packages/app-shell/src/common/hooks/useOrgSwitcher.js
+++ b/packages/app-shell/src/common/hooks/useOrgSwitcher.js
@@ -4,6 +4,7 @@ import { BufferTracker } from '@bufferapp/buffer-tracking-browser-ts'
 
 import { QUERY_ACCOUNT, SET_CURRENT_ORGANIZATION } from '../graphql/account'
 import eventDispatcher from './utils/eventDispatcher'
+import { getActiveProductFromPath } from '../utils/getProduct';
 
 export const EVENT_KEY = 'appshell__organization_event'
 
@@ -50,6 +51,7 @@ function useOrgSwitcher() {
 
     BufferTracker.organizationSwitched({
       organizationId,
+      product: getActiveProductFromPath(),
     });
 
     // Needed, as the onCompleted is not triggered when passed as an option in the mutate function.

--- a/packages/app-shell/src/common/hooks/useSegmentTracking.js
+++ b/packages/app-shell/src/common/hooks/useSegmentTracking.js
@@ -1,5 +1,5 @@
 import { BufferTracker } from '@bufferapp/buffer-tracking-browser-ts'
-import { getProductPath } from '../../components/NavBar';
+import { getActiveProductFromPath } from '../utils/getProduct';
 
 export const formatCTAString = (str) => {
   const result = str.split(/\s+/).map(word => `${word.charAt(0).toUpperCase()}${word.slice(1)}`).join('');
@@ -21,8 +21,7 @@ export const useTrackPlanSelectorViewed = ({ payload, user }) => {
 
   
 
-  const baseUrl = window.location.origin;
-  const product = getProductPath(baseUrl);
+  const product = getActiveProductFromPath();
   const eventData = {
     organizationId: organization.id,
     ctaApp: product,
@@ -50,8 +49,7 @@ export const useTrackPageViewed = ({ payload, user }) => {
     return;
   }
 
-  const baseUrl = window.location.origin;
-  const product = getProductPath(baseUrl);
+  const product = getActiveProductFromPath();
   const eventData = {
     organizationId: organization.id,
     ctaApp: product,

--- a/packages/app-shell/src/common/hooks/useSegmentTracking.js
+++ b/packages/app-shell/src/common/hooks/useSegmentTracking.js
@@ -74,7 +74,7 @@ export const useTrackPageViewed = ({ payload, user }) => {
     referrer: null, // The address of the webpage which is linked to the resource being requested. By checking the referrer, the new webpage can see where the request originated.
     
     ...payload,
-    cta: `${product}-${payload.cta}-planSelector`, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
+    cta: `${product}-${payload.cta}`, // If the user navigated to this page from a CTA on another Buffer page, which call to action was it?
   };
 
   BufferTracker.pageViewed(eventData);

--- a/packages/app-shell/src/common/hooks/useSegmentTracking.test.js
+++ b/packages/app-shell/src/common/hooks/useSegmentTracking.test.js
@@ -132,7 +132,7 @@ describe('useSegmentTracking hooks', () => {
           url: 'http://localhost/the-path?query=the-query',
           path: '/the-path',
           search: '?query=the-query',
-          cta: 'account-addPaymentMethod-planSelector',
+          cta: 'account-addPaymentMethod',
           ctaView: null,
           ctaButton: null,
           channel: null,

--- a/packages/app-shell/src/common/hooks/useStartTrial.js
+++ b/packages/app-shell/src/common/hooks/useStartTrial.js
@@ -3,7 +3,7 @@ import { useMutation } from '@apollo/client';
 import { START_TRIAL } from '../graphql/billing';
 import { QUERY_ACCOUNT } from '../graphql/account';
 
-const useStartTrial = ({ user, plan }) => {
+const useStartTrial = ({ user, plan, attribution }) => {
   const [startTrial, { data: trial, error: mutationError }] = useMutation(
     START_TRIAL,
     {
@@ -20,6 +20,7 @@ const useStartTrial = ({ user, plan }) => {
           organizationId: user.currentOrganization.id,
           plan: plan.planId,
           interval: plan.planInterval,
+          attribution,
         },
       }).catch((e) => {
         console.error(e);

--- a/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
+++ b/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
@@ -4,6 +4,7 @@ import { UPDATE_SUBSCRIPTION_PLAN } from '../graphql/billing';
 import { QUERY_ACCOUNT } from '../graphql/account';
 
 const useUpdateSubscriptionPlan = ({
+  cta,
   user,
   plan,
   hasPaymentMethod,
@@ -29,6 +30,7 @@ const useUpdateSubscriptionPlan = ({
           organizationId: user.currentOrganization.id,
           plan: plan.planId,
           interval: plan.planInterval,
+          attribution: { cta }
         },
       }).catch((e) => {
         console.error(e);

--- a/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.test.jsx
+++ b/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.test.jsx
@@ -7,6 +7,7 @@ import { UPDATE_SUBSCRIPTION_PLAN } from '../graphql/billing';
 import useUpdateSubscriptionPlan from './useUpdateSubscriptionPlan';
 
 describe('useUpdateSubscriptionPlan', () => {
+  const cta = 'testCta';
   const mockSuccessMutation = jest.fn(() => {
     return {
       data: {
@@ -50,6 +51,7 @@ describe('useUpdateSubscriptionPlan', () => {
           organizationId: user.currentOrganization.id,
           plan: plan.planId,
           interval: plan.planInterval,
+          attribution: { cta },
         },
       },
       newData: mockSuccessMutation,
@@ -61,6 +63,7 @@ describe('useUpdateSubscriptionPlan', () => {
           organizationId: userWithError.currentOrganization.id,
           plan: plan.planId,
           interval: plan.planInterval,
+          attribution: { cta },
         },
       },
       newData: mockErrorMutation,
@@ -118,6 +121,7 @@ describe('useUpdateSubscriptionPlan', () => {
     const hasPaymentMethod = true;
     const alreadyProcessing = true;
     const { result, waitForNextUpdate } = testHook({
+      cta,
       user,
       plan,
       hasPaymentMethod,
@@ -138,6 +142,7 @@ describe('useUpdateSubscriptionPlan', () => {
     const hasPaymentMethod = true;
     const alreadyProcessing = true;
     const { result, waitForNextUpdate } = testHook({
+      cta,
       user: userWithError,
       plan,
       hasPaymentMethod,

--- a/packages/app-shell/src/common/utils/getProduct.js
+++ b/packages/app-shell/src/common/utils/getProduct.js
@@ -1,0 +1,5 @@
+export function getActiveProductFromPath() {
+  const baseUrl = window?.location?.origin;
+  const [, productPath] = baseUrl.match(/https*:\/\/(\w+)./) || [];
+  return productPath;
+}

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -51,6 +51,7 @@ export const PlanSelectorContainer = ({
   const [error, setError] = useState(null);
 
   const { data: modalData, modal } = useContext(ModalContext);
+  const cta = modalData && modalData.cta ? modalData.cta : null;
   const { monthlyBilling, setBillingInterval } = useInterval(
     planOptions,
     isUpgradeIntent
@@ -65,6 +66,7 @@ export const PlanSelectorContainer = ({
     error: subscriptionError,
     processing,
   } = useUpdateSubscriptionPlan({
+    cta,
     user,
     plan: selectedPlan,
     hasPaymentMethod: true,
@@ -84,7 +86,6 @@ export const PlanSelectorContainer = ({
   );
 
   useEffect(() => {
-    const cta = modalData && modalData.cta ? modalData.cta : null;
     useTrackPlanSelectorViewed({
       payload: {
         currentPlan: formatCTAString(

--- a/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
@@ -9,10 +9,13 @@ import { MODALS } from '../../../../common/hooks/useModal';
 import { UserContext } from '../../../../common/context/User';
 import { ModalContext } from '../../../../common/context/Modal';
 import useStartTrial from '../../../../common/hooks/useStartTrial';
+import {
+  useTrackPageViewed,
+} from '../../../../common/hooks/useSegmentTracking';
 
 import { Holder, Content, Ctas } from './style';
 
-const StartTrial = ({ user, openModal }) => {
+const StartTrial = ({ user, openModal, modalData }) => {
   const [suggestedPlan, setSuggestedPlan] = useState(null);
   useEffect(() => {
     if (user) {
@@ -39,6 +42,18 @@ const StartTrial = ({ user, openModal }) => {
       openModal(MODALS.success, { startedTrial: true });
     }
   }, [trial]);
+
+  useEffect(() => {
+    const { cta, ctaButton } = modalData || {};
+    useTrackPageViewed({
+      payload: {
+        name: 'AppShell Start Trial',
+        cta,
+        ctaButton,
+      },
+      user,
+    });
+  }, []);
 
   return (
     <Holder>
@@ -111,7 +126,7 @@ const StartTrialProvider = () => {
     <UserContext.Consumer>
       {(user) => (
         <ModalContext.Consumer>
-          {({ openModal }) => <StartTrial user={user} openModal={openModal} />}
+          {({ openModal, data:modalData }) => <StartTrial modalData={modalData} user={user} openModal={openModal} />}
         </ModalContext.Consumer>
       )}
     </UserContext.Consumer>

--- a/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
@@ -17,6 +17,8 @@ import { Holder, Content, Ctas } from './style';
 
 const StartTrial = ({ user, openModal, modalData }) => {
   const [suggestedPlan, setSuggestedPlan] = useState(null);
+  const { cta, ctaButton } = modalData || {};
+
   useEffect(() => {
     if (user) {
       let plan = user.currentOrganization?.billing?.changePlanOptions.find(
@@ -35,6 +37,7 @@ const StartTrial = ({ user, openModal, modalData }) => {
   const { startTrial, trial, error, processing } = useStartTrial({
     user,
     plan: suggestedPlan,
+    attribution: { cta },
   });
 
   useEffect(() => {
@@ -44,7 +47,6 @@ const StartTrial = ({ user, openModal, modalData }) => {
   }, [trial]);
 
   useEffect(() => {
-    const { cta, ctaButton } = modalData || {};
     useTrackPageViewed({
       payload: {
         name: 'AppShell Start Trial',


### PR DESCRIPTION
This properly pass down `attribution` to the `trialStart` and `updateSubscription` migrations  [GROW-190](https://buffer.atlassian.net/browse/GROW-190).

It also fixes the missing product in the `organizationSwitched` event