### PR TITLE
[PUB-3761] Remove new label for Engagement

### DIFF
--- a/packages/app-shell/src/components/NavBar/components/NavBarProducts/NavBarProducts.jsx
+++ b/packages/app-shell/src/components/NavBar/components/NavBarProducts/NavBarProducts.jsx
@@ -141,7 +141,7 @@ const products = [
   {
     id: 'engage',
     label: 'Engagement',
-    isNew: true
+    isNew: false
   }
 ];
 


### PR DESCRIPTION
Engagement will no longer be our newest feature when we launch Canva, so it's time to say farewell to the "New!" label next to Engagement in the Appshell. 👋

Jira ticket: [Remove "New" label from Engagement in the Appshell](https://buffer.atlassian.net/browse/PUB-3761)