### PR TITLE
Add the canMigrateToOneBuffer node to the organizations query

### DIFF
--- a/packages/app-shell/src/common/graphql/account.js
+++ b/packages/app-shell/src/common/graphql/account.js
@@ -104,6 +104,10 @@ export const QUERY_ACCOUNT = gql`
         role
         createdAt
         isOneBufferOrganization
+        canMigrateToOneBuffer {
+          canMigrate
+          reasons
+        }
         shouldDisplayInviteCTA
         featureFlips
         channels {


### PR DESCRIPTION
This is patching the issue with the org switching reported in slack https://buffer.slack.com/archives/C0DLE125Q/p1629295586196200

