### PR TITLE
Hide migration modal if Pendo guide is visible

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,10 @@ module.exports = {
   plugins: ['react', 'testing-library', 'jest-dom'],
   rules: {
     "import/prefer-default-export": "off",
+    "spaced-comment": "off",
+    "no-unneeded-ternary": "off",
+    "import/no-named-as-default": "off",
+    "react/require-default-props": "off"
   },
   ignorePatterns: ['lib/*'], // Stop ESLint complaining when looking at transpiled lib
 };

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -95,19 +95,12 @@ const Modal = ({ modal, openModal }) => {
 
       if(window.pendo && !window.pendo.isGuideShown()) {
         openModal(MODALS.paidMigration);
-        return;
       }
       else {
         if (!window.pendo) {
           openModal(MODALS.paidMigration);
         }
       }
-      // if pendo exists 
-        // then check if pendo window is open
-            // if yes then dont show modal
-            // if no show modal
-      // if pendo doesnt exists
-        // show modal 
     }
   }, [user.loading]);
 

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -17,7 +17,6 @@ import Success from './modals/PaidMigration/Success';
 import StickyModal from './modals/StickyModal';
 
 const ModalContent = ({ modal, closeAction }) => {
-  console.log("here: " + typeof modal);
   switch (modal) {
     case MODALS.paymentMethod:
       return (
@@ -79,7 +78,7 @@ const ModalContent = ({ modal, closeAction }) => {
 };
 
 ModalContent.propTypes = {
-  modal: PropTypes.object.isRequired,
+  modal: PropTypes.objectOf(PropTypes.object).isRequired,
   closeAction: PropTypes.func.isRequired,
 };
 
@@ -95,7 +94,7 @@ const Modal = ({ modal, openModal }) => {
       openModal(MODALS.trialExpired)
     }
 
-    // Check if Pendo loads on the page - we don't want to show the OB Migration modal if there is a Pendo guide already visible
+    //Check if Pendo loads on the page - we don't want to show the OB Migration modal if there is a Pendo guide already visible
     const isPendoModalVisible = window.pendo && !window.pendo.isGuideShown() || !window.pendo ? false : true;
 
     //Migrate to OB modal
@@ -115,7 +114,7 @@ const Modal = ({ modal, openModal }) => {
 };
 
 Modal.propTypes = {
-  modal: PropTypes.object,
+  modal: PropTypes.objectOf(PropTypes.object),
   openModal: PropTypes.func.isRequired,
 };
 

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -95,13 +95,14 @@ const Modal = ({ modal, openModal }) => {
     }
 
     //Check if Pendo loads on the page - we don't want to show the OB Migration modal if there is a Pendo guide already visible
-    const isPendoModalVisible = window.pendo && !window.pendo.isGuideShown() || !window.pendo ? false : true;
+    const isPendoModalVisible = window.pendo && window.pendo.isGuideShown();
 
     //Migrate to OB modal
     const canMigrateToOneBuffer = user?.currentOrganization?.canMigrateToOneBuffer?.canMigrate;
-    const hasDismissedMigrationModal = getCookie({ key: 'migrationModalDismissed' })
+    const hasDismissedMigrationModal = getCookie({ key: 'migrationModalDismissed' });
+    const showMigrationModal = !hasDismissedMigrationModal && canMigrateToOneBuffer && !isPendoModalVisible;
 
-    if (!hasDismissedMigrationModal && canMigrateToOneBuffer && !isPendoModalVisible) {
+    if (showMigrationModal) {
       openModal(MODALS.paidMigration);
     }
   }, [user.loading]);

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import SimpleModal from '@bufferapp/ui/SimpleModal';
+import PropTypes from 'prop-types';
 
 import { getCookie } from '../../common/utils/cookies'
 import { MODALS } from '../../common/hooks/useModal';
@@ -16,6 +17,7 @@ import Success from './modals/PaidMigration/Success';
 import StickyModal from './modals/StickyModal';
 
 const ModalContent = ({ modal, closeAction }) => {
+  console.log("here: " + typeof modal);
   switch (modal) {
     case MODALS.paymentMethod:
       return (
@@ -76,6 +78,11 @@ const ModalContent = ({ modal, closeAction }) => {
   }
 };
 
+ModalContent.propTypes = {
+  modal: PropTypes.object.isRequired,
+  closeAction: PropTypes.func.isRequired,
+};
+
 const Modal = ({ modal, openModal }) => {
   const [hasModal, setHasModal] = useState(!!modal);
   const user = useUser()
@@ -88,19 +95,15 @@ const Modal = ({ modal, openModal }) => {
       openModal(MODALS.trialExpired)
     }
 
+    // Check if Pendo loads on the page - we don't want to show the OB Migration modal if there is a Pendo guide already visible
+    const isPendoModalVisible = window.pendo && !window.pendo.isGuideShown() || !window.pendo ? false : true;
+
     //Migrate to OB modal
     const canMigrateToOneBuffer = user?.currentOrganization?.canMigrateToOneBuffer?.canMigrate;
     const hasDismissedMigrationModal = getCookie({ key: 'migrationModalDismissed' })
-    if (!hasDismissedMigrationModal && canMigrateToOneBuffer) {
 
-      if(window.pendo && !window.pendo.isGuideShown()) {
-        openModal(MODALS.paidMigration);
-      }
-      else {
-        if (!window.pendo) {
-          openModal(MODALS.paidMigration);
-        }
-      }
+    if (!hasDismissedMigrationModal && canMigrateToOneBuffer && !isPendoModalVisible) {
+      openModal(MODALS.paidMigration);
     }
   }, [user.loading]);
 
@@ -109,6 +112,11 @@ const Modal = ({ modal, openModal }) => {
   }, [modal]);
 
   return <>{hasModal && <ModalContent modal={modal} closeAction={() => openModal(null)} />}</>;
+};
+
+Modal.propTypes = {
+  modal: PropTypes.object,
+  openModal: PropTypes.func.isRequired,
 };
 
 export default Modal;

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -92,7 +92,22 @@ const Modal = ({ modal, openModal }) => {
     const canMigrateToOneBuffer = user?.currentOrganization?.canMigrateToOneBuffer?.canMigrate;
     const hasDismissedMigrationModal = getCookie({ key: 'migrationModalDismissed' })
     if (!hasDismissedMigrationModal && canMigrateToOneBuffer) {
-      openModal(MODALS.paidMigration);
+
+      if(window.pendo && !window.pendo.isGuideShown()) {
+        openModal(MODALS.paidMigration);
+        return;
+      }
+      else {
+        if (!window.pendo) {
+          openModal(MODALS.paidMigration);
+        }
+      }
+      // if pendo exists 
+        // then check if pendo window is open
+            // if yes then dont show modal
+            // if no show modal
+      // if pendo doesnt exists
+        // show modal 
     }
   }, [user.loading]);
 


### PR DESCRIPTION
If there is a Pendo guide in place on the page it overlaps the OB migration modal. Talking to Tom and James about it we decided it would be great to only display the migration modal if there are no Pendo guides visible.

![Screen Recording 2021-08-18 at 03 53 42 PM](https://user-images.githubusercontent.com/10730651/129982574-a5953b4c-cd10-482d-bd4b-1df0f81692a7.gif)

I'm using a function in Pendo's script called `pendo.isGuideShown()` to check if any Pendo guides are up on the page. I don't have a ton of context about how Pendo works and I couldn't find any documentation on all the functions available so I'm not sure if this covers all cases. 