### PR TITLE
Don't show OB migration modal if Pendo guide is visible

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     "no-unneeded-ternary": "off",
     "import/no-named-as-default": "off",
     "react/require-default-props": "off",
+    "no-prototype-builtins": "off"
   },
   ignorePatterns: ['lib/*'], // Stop ESLint complaining when looking at transpiled lib
 };

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -94,10 +94,15 @@ const Modal = ({ modal, openModal }) => {
       openModal(MODALS.trialExpired)
     }
 
+    //Check if Pendo loads on the page - we don't want to show the OB Migration modal if there is a Pendo guide already visible
+    const isPendoModalVisible = window.pendo && window.pendo.hasOwnProperty('isGuideShown') && window.pendo.isGuideShown();
+
     //Migrate to OB modal
     const canMigrateToOneBuffer = user?.currentOrganization?.canMigrateToOneBuffer?.canMigrate;
     const hasDismissedMigrationModal = getCookie({ key: 'migrationModalDismissed' })
-    if (!hasDismissedMigrationModal && canMigrateToOneBuffer) {
+    const shouldShowMigrationModal = !hasDismissedMigrationModal && canMigrateToOneBuffer && !isPendoModalVisible;
+
+    if (shouldShowMigrationModal) {
       openModal(MODALS.paidMigration);
     }
   }, [user.loading]);


### PR DESCRIPTION
If there is a Pendo guide in place on the page it overlaps the OB migration modal. Talking to Tom and James about it we decided it would be great to only display the migration modal if there are no Pendo guides visible.

I'm using a function in Pendo's API called `pendo.isGuideShown()` to check if any Pendo guides are up on the page. I don't have a ton of context about how Pendo works and I couldn't find any documentation on all the functions available so I'm not sure if this covers all cases.

![Screen Recording 2021-08-18 at 03 53 42 PM](https://user-images.githubusercontent.com/10730651/130697421-f3768314-1476-4c05-9cf2-69badb50e1c9.gif)
