### PR TITLE
[FIX] Add eslitn cypress package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,15 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
+    jest: true,
   },
-  extends: ['plugin:react/recommended', 'airbnb', 'prettier', 'prettier/react'],
+  extends: [
+    'plugin:react/recommended',
+    'airbnb',
+    'prettier',
+    'prettier/react',
+    'plugin:cypress/recommended',
+  ],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -13,11 +20,11 @@ module.exports = {
   },
   plugins: ['react', 'testing-library', 'jest-dom'],
   rules: {
-    "import/prefer-default-export": "off",
-    "spaced-comment": "off",
-    "no-unneeded-ternary": "off",
-    "import/no-named-as-default": "off",
-    "react/require-default-props": "off",
+    'import/prefer-default-export': 'off',
+    'spaced-comment': 'off',
+    'no-unneeded-ternary': 'off',
+    'import/no-named-as-default': 'off',
+    'react/require-default-props': 'off',
   },
   ignorePatterns: ['lib/*'], // Stop ESLint complaining when looking at transpiled lib
 };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "cypress": "^8.2.0",
+    "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-jest-dom": "^3.6.3",
     "eslint-plugin-testing-library": "^3.10.1",
     "lerna": "^3.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8099,6 +8099,13 @@ eslint-module-utils@^2.6.1:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+eslint-plugin-cypress@^2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.3.tgz#54ee4067aa8192aa62810cd35080eb577e191ab7"
+  integrity sha512-hOoAid+XNFtpvOzZSNWP5LDrQBEJwbZwjib4XJ1KcRYKjeVj0mAmPmucG4Egli4j/aruv+Ow/acacoloWWCl9Q==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-plugin-flowtype@^5.2.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.7.2.tgz#482a42fe5d15ee614652ed256d37543d584d7bc0"
@@ -9343,7 +9350,7 @@ global@^4.4.0:
     min-document "^2.19.0"
     process "^0.11.10"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.12.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
This removes many eslint errors when working in testing files

This PR installed a new package at the root level `"eslint-plugin-cypress": "^2.11.3",` and updates the `.eslintconfig` to handle test packages.
This was installed this to get rid of a large amount of eslint errors which are in the package due to test files using jest and cypress

This helps reduce/fix errors that appear if you run `yarn run lint` in the repo, from 674 problems down to 280 problems.

These are the types of eslint errors this fixes:
![Screen Shot 2021-08-25 at 2 13 14 pm](https://user-images.githubusercontent.com/7763710/130740314-70dbcb50-093a-4bbb-9b62-37108b91701b.png)

Before adding this change working in test files looked like this:
![Screen Shot 2021-08-25 at 1 58 23 pm](https://user-images.githubusercontent.com/7763710/130740368-3a466b93-7bbf-467c-a778-c499522ecf11.png)

Before change this is how many problems `yarn lint` showed:
![Screen Shot 2021-08-25 at 2 12 40 pm](https://user-images.githubusercontent.com/7763710/130740416-2d4b3c5d-e836-462b-ae07-a058709a946c.png)

After change this is how many problems `yarn lint` showed:
![Screen Shot 2021-08-25 at 2 13 53 pm](https://user-images.githubusercontent.com/7763710/130740437-cdd93c19-4aa2-4bef-a725-aade1ac889fe.png)

