### PR TITLE
Fix the plan name in the trial banner

### DIFF
--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -84,7 +84,7 @@ export const Navigator = ({ apolloClient, channels }) => {
       const daysRemaining =
         user.currentOrganization?.billing?.subscription?.trial?.remainingDays;
       trialBannerString = `You are on the Essentials plan ${
-        planName === 'Team' ? 'with Team Pack' : ''
+        planName === 'Essentials' ? '' : 'with Team Pack'
       } trial with ${daysRemaining} ${
         daysRemaining === 1 ? 'day' : 'days'
       } left. Add your billing details now to start your subscription.`;


### PR DESCRIPTION
`Team` is not a plan that we return anymore. We have `Essentials` and `Essentials + Team`. 
I made this fix here to fix the issue for the production, but we should perhaps let the backend generate that string and use it as we get it, then we don't have to maintain the logic here.