### PR TITLE
fix isMultiProductCustomer trait

### DIFF
--- a/packages/app-shell/src/common/hooks/useUserTracker.test.js
+++ b/packages/app-shell/src/common/hooks/useUserTracker.test.js
@@ -140,10 +140,10 @@ describe('useUserTracker hooks', () => {
       groupUser(OBUser)
       expect(global.analytics.group)
         .toHaveBeenCalledWith(OBUser.currentOrganization.id, expect.objectContaining({
-          currentAnalyzePlan: null,
+          currentAnalyzePlan: 'free',
           currentBufferPlan: 'team',
           currentBufferTrialPlan: null,
-          currentPublishPlan: null,
+          currentPublishPlan: 'free',
           isOnPublishTrial: false,
           isOneBufferEnabled: true,
           isPayingAnalyzeOrganization: false,

--- a/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.js
+++ b/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.js
@@ -1,11 +1,44 @@
 export function isMultiProductCustomer({ currentOrganization }) {
   if (!currentOrganization?.isOneBufferOrganization) {
     if (currentOrganization?.billing?.subscriptions?.length > 1) {
-      return true;
+      const activeSubscriptions = currentOrganization.billing.subscriptions
+        .filter(subscription => !subscription?.trial?.isActive);
+      return activeSubscriptions.length > 1;
     }
   }
 
   return false;
+}
+
+export function isOnBufferTrial({ currentOrganization }) {
+  return currentOrganization?.billing?.subscription?.plan?.trial?.isActive || false
+}
+
+function getMPSubscription(currentOrganization, product) {
+  if (currentOrganization?.billing?.subscriptions?.length > 0) {
+    return currentOrganization?.billing?.subscriptions
+      .find(s => s.product === product) || null
+  }
+
+  return null;
+}
+
+function getPublishSubscription(currentOrganization) {
+  return getMPSubscription(currentOrganization, 'publish');
+}
+
+function getAnalyzeSubscription(currentOrganization) {
+  return getMPSubscription(currentOrganization, 'analyze');
+}
+
+export function isOnAnalyzeTrial({ currentOrganization }) {
+    const subscription = getAnalyzeSubscription(currentOrganization)
+    return subscription?.trial?.isActive || false
+}
+
+export function isOnPublishTrial({ currentOrganization }) {
+    const subscription = getPublishSubscription(currentOrganization)
+    return subscription?.trial?.isActive || false
 }
 
 export function isFreePlan(user) {
@@ -50,23 +83,6 @@ export function isPayingBufferOrganization({ currentOrganization }) {
   return false;
 }
 
-function getMPSubscription(currentOrganization, product) {
-  if (currentOrganization?.billing?.subscriptions?.length > 0) {
-    return currentOrganization?.billing?.subscriptions
-      .find(s => s.product === product) || null
-  }
-
-  return null;
-}
-
-function getPublishSubscription(currentOrganization) {
-  return getMPSubscription(currentOrganization, 'publish');
-}
-
-function getAnalyzeSubscription(currentOrganization) {
-  return getMPSubscription(currentOrganization, 'analyze');
-}
-
 export function currentAnalyzePlan({ currentOrganization }) {
   if(!isOnAnalyzeTrial({ currentOrganization })) {
     const subscription = getAnalyzeSubscription(currentOrganization)
@@ -76,12 +92,6 @@ export function currentAnalyzePlan({ currentOrganization }) {
   return null;
 }
 
-export function isOnAnalyzeTrial({ currentOrganization }) {
-    const subscription = getAnalyzeSubscription(currentOrganization)
-    return subscription?.trial?.isActive || false
-}
-
-
 export function currentAnalyzeTrialPlan({ currentOrganization }) {
   if (isOnAnalyzeTrial({ currentOrganization })) {
     const subscription = getAnalyzeSubscription(currentOrganization)
@@ -89,11 +99,6 @@ export function currentAnalyzeTrialPlan({ currentOrganization }) {
   }
 
   return null;
-}
-
-export function isOnPublishTrial({ currentOrganization }) {
-    const subscription = getPublishSubscription(currentOrganization)
-    return subscription?.trial?.isActive || false
 }
 
 export function currentPublishPlan({ currentOrganization }) {
@@ -112,10 +117,6 @@ export function currentPublishTrialPlan({ currentOrganization }) {
   }
 
   return null;
-}
-
-export function isOnBufferTrial({ currentOrganization }) {
-  return currentOrganization?.billing?.subscription?.plan?.trial?.isActive || false
 }
 
 export function billingCycle({ currentOrganization }) {

--- a/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.js
+++ b/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.js
@@ -86,10 +86,10 @@ export function isPayingBufferOrganization({ currentOrganization }) {
 export function currentAnalyzePlan({ currentOrganization }) {
   if(!isOnAnalyzeTrial({ currentOrganization })) {
     const subscription = getAnalyzeSubscription(currentOrganization)
-    return subscription?.plan || null
+    return subscription?.plan || 'free'
   }
 
-  return null;
+  return 'free';
 }
 
 export function currentAnalyzeTrialPlan({ currentOrganization }) {
@@ -104,10 +104,10 @@ export function currentAnalyzeTrialPlan({ currentOrganization }) {
 export function currentPublishPlan({ currentOrganization }) {
   if(!isOnPublishTrial({ currentOrganization })) {
     const subscription = getPublishSubscription(currentOrganization)
-    return subscription?.plan || null
+    return subscription?.plan || 'free'
   }
 
-  return null;
+  return 'free';
 }
 
 export function currentPublishTrialPlan({ currentOrganization }) {

--- a/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.test.js
+++ b/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.test.js
@@ -272,7 +272,7 @@ describe('Segment Traits Getters', () => {
             ]
           }
         }
-      })).toBeNull();
+      })).toEqual('free');
     });
 
     it('should return null for analyze trial user', () => {
@@ -284,11 +284,11 @@ describe('Segment Traits Getters', () => {
             ]
           }
         }
-      })).toBeNull();
+      })).toEqual('free');
     });
 
     it('should return null for OBUser', () => {
-      expect(currentAnalyzePlan(OBUser)).toBeNull();
+      expect(currentAnalyzePlan(OBUser)).toEqual('free');
     });
   });
 
@@ -340,7 +340,7 @@ describe('Segment Traits Getters', () => {
             ]
           }
         }
-      })).toBeNull();
+      })).toEqual('free');
     });
 
     it('should return null for publish trial user', () => {
@@ -352,11 +352,11 @@ describe('Segment Traits Getters', () => {
             ]
           }
         }
-      })).toBeNull();
+      })).toEqual('free');
     });
 
     it('should return null for OBUser', () => {
-      expect(currentPublishPlan(OBUser)).toBeNull();
+      expect(currentPublishPlan(OBUser)).toEqual('free');
     });
   });
 

--- a/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.test.js
+++ b/packages/app-shell/src/common/hooks/utils/segmentTraitGetters.test.js
@@ -84,6 +84,20 @@ describe('Segment Traits Getters', () => {
         },
       })).toBeFalsy();
     });
+
+    it('should not flag as MP user with trialing subscription', () => {
+      expect(isMultiProductCustomer({
+        currentOrganization: {
+          isOneBufferOrganization: false,
+          billing: {
+            subscriptions: [
+              { plan: "pro", product: "publish", interval: 'month', trial: { isActive: false } },
+              { plan: "pro", product: "publish", interval: 'month', trial: { isActive: true } },
+            ]
+          },
+        },
+      })).toBeFalsy();
+    });
   })
 
   describe('isFreePlan', () => {


### PR DESCRIPTION
Follow up to https://github.com/bufferapp/core-authentication-service/pull/1256/, to make sure we are not tracking as MP an org that is trialing.