### PR TITLE
Track when the OB migration modal is viewed

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
@@ -24,13 +24,13 @@ export const EssentialsPlan = ({ features }) => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
-    const productFromPath = getActiveProductFromPath();
+    const product = getActiveProductFromPath();
 
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'Value',
-        product: productFromPath,
+        product,
         cta,
         ctaButton,
       },

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
@@ -14,6 +14,7 @@ import { MODALS } from '../../../../../common/hooks/useModal';
 import {
   useTrackPageViewed,
 } from '../../../../../common/hooks/useSegmentTracking';
+import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
 
 import * as styles from './style';
 
@@ -23,10 +24,13 @@ export const EssentialsPlan = ({ features }) => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
+    const productFromPath = getActiveProductFromPath();
+
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'Value',
+        product: productFromPath,
         cta,
         ctaButton,
       },

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
@@ -6,14 +6,33 @@ import FlashIcon from '@bufferapp/ui/Icon/Icons/Flash';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
 import { purple, white } from '@bufferapp/ui/style/colors';
 
-import { useUser } from '../../../../../common/context/User';
+import { useUser, UserContext } from '../../../../../common/context/User';
 import useMigrationPlanPreview from '../hooks/useMigrationPlanPreview';
 import { ModalContext } from '../../../../../common/context/Modal';
 import { MODALS } from '../../../../../common/hooks/useModal';
+import {
+  useTrackPageViewed,
+} from '../../../../../common/hooks/useSegmentTracking';
 
 import * as styles from './style';
 
 export const EssentialsPlan = ({ features }) => {
+  const currentUser = useContext(UserContext);
+  const { data } = useContext(ModalContext);
+  const { cta, ctaButton } = data || {};
+
+  useEffect(() => {
+    useTrackPageViewed({
+      payload: {
+        name: 'Migrate to OB Modal',
+        title: 'Value',
+        cta,
+        ctaButton,
+      },
+      user: currentUser,
+    });
+  }, []);
+  
   const checkIfTrue = (plan) => {
     switch (plan) {
       case true:

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPlan/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
@@ -51,6 +52,7 @@ export const EssentialsPlan = ({ features }) => {
               src="https://buffer-ui.s3.amazonaws.com/avatars/avatar-joel.jpg"
               width="117"
               height="117"
+              alt="Joel Gascoigne avatar"
             />
             <Text type="p">
               Hey, it’s Joel the CEO here. We’re embarking on a new future here
@@ -134,7 +136,7 @@ export const EssentialsPlan = ({ features }) => {
               <styles.FeaturesTable>
                 <thead>
                   <tr>
-                    <th></th>
+                    <th aria-label="Plans features" />
                     <th scope="col">
                       <styles.PlanLabel>
                         <Text type="p">Current Plan</Text>
@@ -156,8 +158,8 @@ export const EssentialsPlan = ({ features }) => {
                 </thead>
 
                 <tbody>
-                  {features.map((feature, index) => (
-                    <tr key={`row-${index}`}>
+                  {features.map((feature) => (
+                    <tr key={`row-${feature.title}`}>
                       <td>
                         <Text type="p">
                           <b>{feature.title}</b>
@@ -210,4 +212,8 @@ export default function() {
     suggestedPlan: migrationPreview.suggestedPlan.supportedFeatures.includes(feature.id),
   }))
   return (<EssentialsPlan features={features} />);
+};
+
+EssentialsPlan.propTypes = {
+  features: PropTypes.objectOf(PropTypes.object).isRequired,
 };

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
@@ -7,7 +7,7 @@ import ArrowLeftIcon from '@bufferapp/ui/Icon/Icons/ArrowLeft';
 
 import { MODALS } from '../../../../../common/hooks/useModal';
 import { ModalContext } from '../../../../../common/context/Modal';
-import { useUser } from '../../../../../common/context/User';
+import { useUser, UserContext } from '../../../../../common/context/User';
 import useMigrationPlanPreview from '../hooks/useMigrationPlanPreview';
 import useMigrateToOB from '../hooks/useMigrateToOB';
 
@@ -30,6 +30,22 @@ import {
 } from './style';
 
 const PeriodEndString =({ migrationPreview }) => {
+  const currentUser = useContext(UserContext);
+  const { data } = useContext(ModalContext);
+  const { cta, ctaButton } = data || {};
+
+  useEffect(() => {
+    useTrackPageViewed({
+      payload: {
+        name: 'Migrate to OB Modal',
+        title: 'OB Pricing',
+        cta,
+        ctaButton,
+      },
+      user: currentUser,
+    });
+  }, []);
+
   const months = [
     'January',
     'February',

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -12,6 +12,10 @@ import useMigrationPlanPreview from '../hooks/useMigrationPlanPreview';
 import useMigrateToOB from '../hooks/useMigrateToOB';
 
 import {
+  useTrackPageViewed,
+} from '../../../../../common/hooks/useSegmentTracking';
+
+import {
   Holder,
   FeaturesList,
   LeftColumn,

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -15,6 +15,7 @@ import useMigrateToOB from '../hooks/useMigrateToOB';
 import {
   useTrackPageViewed,
 } from '../../../../../common/hooks/useSegmentTracking';
+import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
 
 import {
   Holder,
@@ -33,6 +34,7 @@ import {
   PriceFooterWrapper,
   ButtonContainer,
 } from './style';
+import { productSignup } from '@bufferapp/buffer-tracking-browser-ts';
 
 const PeriodEndString =({ migrationPreview }) => {
   const currentUser = useContext(UserContext);
@@ -40,10 +42,13 @@ const PeriodEndString =({ migrationPreview }) => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
+    const productFromPath = getActiveProductFromPath();
+
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'OB Pricing',
+        product: productFromPath,
         cta,
         ctaButton,
       },

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
@@ -124,24 +125,22 @@ export const Content = ({
         <Body>
           <Text type="h2">Your upgrade</Text>
           <SummaryDetails>
-            {
-              <>
-                <DetailList>
-                  {migrationPreview.migrationSummary.details.map((detail) => (
-                    <Detail key={detail}>
-                      <Text type="p">{detail}</Text>
-                    </Detail>
-                  ))}
-                </DetailList>
-                <Separator />
-                <SummaryNote>
-                  <Text type="p">
-                    Payment made today is pro rata of new plan price until the
-                    next billing cycle begins <PeriodEndString migrationPreview={migrationPreview} />
-                  </Text>
-                </SummaryNote>
-              </>
-            }
+            <>
+              <DetailList>
+                {migrationPreview.migrationSummary.details.map((detail) => (
+                  <Detail key={detail}>
+                    <Text type="p">{detail}</Text>
+                  </Detail>
+                ))}
+              </DetailList>
+              <Separator />
+              <SummaryNote>
+                <Text type="p">
+                  Payment made today is pro rata of new plan price until the
+                  next billing cycle begins <PeriodEndString migrationPreview={migrationPreview} />
+                </Text>
+              </SummaryNote>
+            </>
           </SummaryDetails>
 
           <Bottom>
@@ -177,8 +176,8 @@ export const Content = ({
 
 const EssentialsPricing = ({ openModal }) => {
   const user = useUser();
-  const { data:migrationPreview, loading, error:previewError } = useMigrationPlanPreview(user)
-  const { migrateToOB, success, error:migrateError, processing } = useMigrateToOB(user)
+  const { data:migrationPreview, loading } = useMigrationPlanPreview(user)
+  const { migrateToOB, success, processing } = useMigrateToOB(user)
 
   if (loading) {
     return null;
@@ -214,4 +213,19 @@ export default function() {
       <EssentialsPricing openModal={openModal} />
     )}
   </ModalContext.Consumer>);
+};
+
+PeriodEndString.propTypes = {
+  migrationPreview: PropTypes.objectOf(PropTypes.object).isRequired,
+};
+
+Content.propTypes = {
+  migrationPreview: PropTypes.objectOf(PropTypes.object).isRequired,
+  handleMigrate: PropTypes.func,
+  handleDismiss: PropTypes.func,
+  processing: PropTypes.func,
+};
+
+EssentialsPricing.propTypes = {
+  openModal: PropTypes.func.isRequired,
 };

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -34,7 +34,6 @@ import {
   PriceFooterWrapper,
   ButtonContainer,
 } from './style';
-import { productSignup } from '@bufferapp/buffer-tracking-browser-ts';
 
 const PeriodEndString =({ migrationPreview }) => {
   const currentUser = useContext(UserContext);
@@ -42,13 +41,13 @@ const PeriodEndString =({ migrationPreview }) => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
-    const productFromPath = getActiveProductFromPath();
+    const product = getActiveProductFromPath();
 
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'OB Pricing',
-        product: productFromPath,
+        product,
         cta,
         ctaButton,
       },

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
@@ -42,8 +42,8 @@ const Intro = () => {
     <ModalContext.Consumer>
       {({ openModal }) => (
         <Holder>
-          <BackgroundLayerBottom></BackgroundLayerBottom>
-          <BackgroundLayerTop></BackgroundLayerTop>
+          <BackgroundLayerBottom/>
+          <BackgroundLayerTop/>
           <IconWrapper>
             <FlashIcon size="large" />
           </IconWrapper>

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
 import FlashIcon from '@bufferapp/ui/Icon/Icons/Flash';
 import { setCookie, DATES } from '../../../../../common/utils/cookies';
 import { ModalContext } from '../../../../../common/context/Modal';
+import { UserContext } from '../../../../../common/context/User';
 import { MODALS } from '../../../../../common/hooks/useModal';
+
+import {
+  useTrackPageViewed,
+} from '../../../../../common/hooks/useSegmentTracking';
 
 import {
   Holder,
@@ -17,6 +22,22 @@ import {
 } from './style';
 
 const Intro = () => {
+  const currentUser = useContext(UserContext);
+  const { data } = useContext(ModalContext);
+  const { cta, ctaButton } = data || {};
+
+  useEffect(() => {
+    useTrackPageViewed({
+      payload: {
+        name: 'Migrate to OB Modal',
+        title: 'Intro',
+        cta,
+        ctaButton,
+      },
+      user: currentUser,
+    });
+  }, []);
+
   return (
     <ModalContext.Consumer>
       {({ openModal }) => (

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
@@ -28,13 +28,13 @@ const Intro = () => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
-    const productFromPath = getActiveProductFromPath();
+    const product = getActiveProductFromPath();
 
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'Intro',
-        product: productFromPath,
+        product,
         cta,
         ctaButton,
       },

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/Intro/index.jsx
@@ -11,6 +11,7 @@ import { MODALS } from '../../../../../common/hooks/useModal';
 import {
   useTrackPageViewed,
 } from '../../../../../common/hooks/useSegmentTracking';
+import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
 
 import {
   Holder,
@@ -27,10 +28,13 @@ const Intro = () => {
   const { cta, ctaButton } = data || {};
 
   useEffect(() => {
+    const productFromPath = getActiveProductFromPath();
+
     useTrackPageViewed({
       payload: {
         name: 'Migrate to OB Modal',
         title: 'Intro',
+        product: productFromPath,
         cta,
         ctaButton,
       },


### PR DESCRIPTION
Track views on the various stages of the OB migration modal. 

NOTE: I've added the tracker to the first 3 stages but left out of the last (Success) one as I thought it might not be valuable to track views for it. Let me know if that's not the case 🙂 