### PR TITLE
Append displayName to styles to prevent style collision

### DIFF
--- a/packages/app-shell/babel.config.json
+++ b/packages/app-shell/babel.config.json
@@ -10,6 +10,13 @@
       }
     ]
   ],
+  "plugins": [
+    [
+      "babel-plugin-styled-components", {
+        "displayName": "true"
+      }
+    ]
+  ],
   "env": {
     "test": {
       "plugins": [

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -42,6 +42,7 @@
     "@storybook/react": "^6.1.19",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^5.0.3",
+    "babel-plugin-styled-components": "^1.13.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.11.0",
     "eslint-config-airbnb": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5394,6 +5394,16 @@ babel-plugin-react-docgen@^4.2.1:
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
 
+babel-plugin-styled-components@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.2.tgz#ebe0e6deff51d7f93fceda1819e9b96aeb88278d"
+  integrity sha512-Vb1R3d4g+MUfPQPVDMCGjm3cDocJEUTR7Xq7QS95JWWeksN1wdFRYpD2kulDgI3Huuaf1CZd+NK4KQmqUFh5dA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
It looks like [running two frontend apps with styled-components can lead to style collision](https://github.com/styled-components/styled-components/issues/2974#issuecomment-786990647), and it's recommended to process each bundle with `babel-plugin-styled-components` and `displayName: true`.

This seems to be what was causing the issue in production for Start Pages.

Context:

- Slack [link](https://buffer.slack.com/archives/C0YS0TW5P/p1631752164345900)
- Paper [link](https://paper.dropbox.com/doc/SP-prod-vs-dev-style-collision-investigation--BScpeC1SxU6A1mWLc8IdRzImAg-5ata9YNaynVGaIvr5ZGNL)