### PR TITLE
improve animation of the plan selector confirmation modal [PUB-3836]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,12 +20,13 @@ module.exports = {
   },
   plugins: ['react', 'testing-library', 'jest-dom'],
   rules: {
-    'import/prefer-default-export': 'off',
-    'spaced-comment': 'off',
-    'no-unneeded-ternary': 'off',
+    "react/prop-types": 'off',
     'import/no-named-as-default': 'off',
-    'react/require-default-props': 'off',
+    'import/prefer-default-export': 'off',
     'no-prototype-builtins': 'off',
+    'no-unneeded-ternary': 'off',
+    'react/require-default-props': 'off',
+    'spaced-comment': 'off',
   },
   ignorePatterns: ['lib/*'], // Stop ESLint complaining when looking at transpiled lib
 };

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "@bufferapp/buffer-tracking-browser-ts": "^0.0.21",
-    "@bufferapp/ui": "^5.66.0",
+    "@bufferapp/ui": "^5.75.5",
     "@storybook/addon-actions": "^6.1.19",
     "@storybook/addon-essentials": "^6.1.19",
     "@storybook/addon-links": "^6.1.19",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@bufferapp/buffer-tracking-browser-ts": "^0.0.21",
-    "@bufferapp/ui": "^5.66.0",
+    "@bufferapp/ui": "^5.75.5",
     "prop-types": ">= 15.7.2",
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",

--- a/packages/app-shell/src/common/hooks/useStartTrial.js
+++ b/packages/app-shell/src/common/hooks/useStartTrial.js
@@ -8,6 +8,7 @@ const useStartTrial = ({ user, plan, attribution }) => {
     START_TRIAL,
     {
       refetchQueries: [{ query: QUERY_ACCOUNT }],
+      awaitRefetchQueries: true,
     }
   );
   const [processing, setProcessing] = useState(false);
@@ -23,7 +24,7 @@ const useStartTrial = ({ user, plan, attribution }) => {
           attribution,
         },
       }).catch((e) => {
-        console.error(e);
+        console.error(e); // eslint-disable-line no-console
       });
     }
   }, [processing]);

--- a/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
+++ b/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
@@ -17,6 +17,7 @@ const useUpdateSubscriptionPlan = ({
     UPDATE_SUBSCRIPTION_PLAN,
     {
       refetchQueries: [{ query: QUERY_ACCOUNT }],
+      awaitRefetchQueries: true,
     }
   );
 
@@ -33,7 +34,7 @@ const useUpdateSubscriptionPlan = ({
           attribution: { cta }
         },
       }).catch((e) => {
-        console.error(e);
+        console.error(e); // eslint-disable-line no-console
       });
     }
   }, [processing, hasPaymentMethod]);

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -82,7 +82,7 @@ ModalContent.propTypes = {
   closeAction: PropTypes.func.isRequired,
 };
 
-const Modal = ({ modal, openModal }) => {
+const Modal = React.memo(({ modal, openModal }) => {
   const [hasModal, setHasModal] = useState(!!modal);
   const user = useUser()
 
@@ -112,7 +112,7 @@ const Modal = ({ modal, openModal }) => {
   }, [modal]);
 
   return <>{hasModal && <ModalContent modal={modal} closeAction={() => openModal(null)} />}</>;
-};
+});
 
 Modal.propTypes = {
   modal: PropTypes.objectOf(PropTypes.object),

--- a/packages/app-shell/src/components/Modal/modals/PaymentMethod/hooks/useUpdateUserPaymentMethod.js
+++ b/packages/app-shell/src/components/Modal/modals/PaymentMethod/hooks/useUpdateUserPaymentMethod.js
@@ -1,14 +1,10 @@
 import { useEffect , useState} from 'react';
 import { useMutation } from '@apollo/client';
 import { UPDATE_PAYMENT_METHOD } from '../../../../../common/graphql/billing';
-import { QUERY_ACCOUNT } from '../../../../../common/graphql/account';
 
 function useUpdateUserPaymentMethod({ user, paymentMethod }) {
   const [updatePaymentMethod, { data, error: mutationError }] = useMutation(
     UPDATE_PAYMENT_METHOD,
-    {
-      refetchQueries: [{ query: QUERY_ACCOUNT }],
-    }
   );
   const [error, setError] = useState(null);
 
@@ -20,7 +16,7 @@ function useUpdateUserPaymentMethod({ user, paymentMethod }) {
           paymentMethodId: paymentMethod.id,
         },
       }).catch((e) => {
-        console.error(e);
+        console.error(e); // eslint-disable-line no-console
       });
     }
   }, [paymentMethod]);

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -39,14 +39,14 @@ export const PlanSelectorContainer = ({
   isFreePlan,
   isUpgradeIntent,
 }) => {
-  const filterPlanOptions = (changePlanOptions) => {
+  const filterPlanOptions = () => {
     if (isUpgradeIntent) {
       return changePlanOptions.filter((option) => option.planId !== 'free');
     }
     return changePlanOptions;
   };
 
-  const planOptions = filterPlanOptions(changePlanOptions);
+  const planOptions = filterPlanOptions();
 
   const [error, setError] = useState(null);
 
@@ -93,7 +93,7 @@ export const PlanSelectorContainer = ({
         ),
         screenName: headerLabel,
         cta,
-        ctaButton: ctaButton,
+        ctaButton,
       },
       user,
     });
@@ -103,7 +103,7 @@ export const PlanSelectorContainer = ({
         name: 'planSelection',
         title: 'planSelector',
         cta,
-        ctaButton: ctaButton,
+        ctaButton,
       },
       user,
     });
@@ -121,7 +121,7 @@ export const PlanSelectorContainer = ({
 
   useEffect(() => {
     if (data?.billingUpdateSubscriptionPlan.success) {
-      openSuccess({ selectedPlan });
+      openSuccess({ selectedPlan })
     }
     if (subscriptionError) {
       setError(subscriptionError);
@@ -165,7 +165,7 @@ export const PlanSelectorContainer = ({
       <Right>
         <Summary
           selectedPlan={selectedPlan}
-          fromPlanSelector={true}
+          fromPlanSelector
           isUpgradeIntent={isUpgradeIntent}
         />
         <ButtonContainer>

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -28,7 +28,7 @@ function getActiveProductFromUrl() {
   return null;
 }
 
-export const Navigator = ({ apolloClient, channels }) => {
+export const Navigator = React.memo(({ apolloClient, channels }) => {
   const graphqlConfig = apolloClient
     ? {
         client: apolloClient,
@@ -116,7 +116,7 @@ export const Navigator = ({ apolloClient, channels }) => {
       </ModalContext.Provider>
     </UserContext.Provider>
   );
-};
+});
 
 Navigator.propTypes = {
   apolloClient: PropTypes.instanceOf(ApolloClient),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
   dependencies:
     "@types/segment-analytics" "0.0.33"
 
-"@bufferapp/ui@^5.66.0":
-  version "5.67.0"
-  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.67.0.tgz#23aee42a8f706ab57df2e192d20980c207fe57bc"
-  integrity sha512-vHfyh97gkmbZWy1kNmvX/uLFdHdccYBGgByKugD6ftd4vTH+Kxc11kyqpBx/B5BheRkLmzFgklowJP8f8PG9uw==
+"@bufferapp/ui@^5.75.5":
+  version "5.75.5"
+  resolved "https://registry.yarnpkg.com/@bufferapp/ui/-/ui-5.75.5.tgz#2ada9722542ec768d555fbbc46784c2be1a1719c"
+  integrity sha512-3OZZaQza2jaWhtXKvN7srWW/4/kYww88cHFyVYqvndruwAfMXDHDyximDbvJSOoBMh1WjWdyodTxeTBYtUMHNA==
   dependencies:
     "@reach/tooltip" "0.6.2"
     immutability-helper "^2.9.0"


### PR DESCRIPTION
Prevent double rendering of the confirmation modal, that was caused by Account query refreshing after the mutation was completed.
fixes: [PUB-3836](https://buffer.atlassian.net/browse/PUB-3836)