### PR TITLE
[FIX] Change copy for Migrate to Essentials

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -155,13 +155,13 @@ export const Content = ({
             <TotalPrice>
               <sup>$</sup>
               <Text type="h2" as="p">
-                {migrationPreview.preview.currentPlan.interval === 'month'
+                {migrationPreview.currentPlan.interval === 'month'
                   ? migrationPreview.migrationSummary.totalPrice
                   : `${migrationPreview.migrationSummary.totalPrice}/yearly`}
               </Text>
             </TotalPrice>
             <PriceFooterWrapper>
-              {migrationPreview.preview.currentPlan.interval === 'month' && (
+              {migrationPreview.currentPlan.interval === 'month' && (
                 <Text type="p" color="grayDark">
                   Billed monthly in USD
                 </Text>

--- a/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaidMigration/EssentialsPricing/index.jsx
@@ -12,9 +12,7 @@ import { useUser, UserContext } from '../../../../../common/context/User';
 import useMigrationPlanPreview from '../hooks/useMigrationPlanPreview';
 import useMigrateToOB from '../hooks/useMigrateToOB';
 
-import {
-  useTrackPageViewed,
-} from '../../../../../common/hooks/useSegmentTracking';
+import { useTrackPageViewed } from '../../../../../common/hooks/useSegmentTracking';
 import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
 
 import {
@@ -35,7 +33,7 @@ import {
   ButtonContainer,
 } from './style';
 
-const PeriodEndString =({ migrationPreview }) => {
+const PeriodEndString = ({ migrationPreview }) => {
   const currentUser = useContext(UserContext);
   const { data } = useContext(ModalContext);
   const { cta, ctaButton } = data || {};
@@ -67,18 +65,23 @@ const PeriodEndString =({ migrationPreview }) => {
     'September',
     'October',
     'November',
-    'December'
-  ]
+    'December',
+  ];
 
   if (migrationPreview?.currentPlan?.periodEnd) {
     const date = new Date(migrationPreview.currentPlan.periodEnd);
-    return (<>
-      on <b>{months[date.getMonth()]} {date.getDate()}, {date.getFullYear()}</b>
-    </>)
+    return (
+      <>
+        on{' '}
+        <b>
+          {months[date.getMonth()]} {date.getDate()}, {date.getFullYear()}
+        </b>
+      </>
+    );
   }
 
-  return null
-}
+  return null;
+};
 
 export const Content = ({
   migrationPreview,
@@ -141,7 +144,8 @@ export const Content = ({
               <SummaryNote>
                 <Text type="p">
                   Payment made today is pro rata of new plan price until the
-                  next billing cycle begins <PeriodEndString migrationPreview={migrationPreview} />
+                  next billing cycle begins{' '}
+                  <PeriodEndString migrationPreview={migrationPreview} />
                 </Text>
               </SummaryNote>
             </>
@@ -151,19 +155,23 @@ export const Content = ({
             <TotalPrice>
               <sup>$</sup>
               <Text type="h2" as="p">
-                {migrationPreview.migrationSummary.totalPrice}
+                {migrationPreview.preview.currentPlan.interval === 'month'
+                  ? migrationPreview.migrationSummary.totalPrice
+                  : `${migrationPreview.migrationSummary.totalPrice}/yearly`}
               </Text>
             </TotalPrice>
-
             <PriceFooterWrapper>
+              {migrationPreview.preview.currentPlan.interval === 'month' && (
+                <Text type="p" color="grayDark">
+                  Billed monthly in USD
+                </Text>
+              )}
+
               <Text type="p" color="grayDark">
-                Billed monthly in USD
-              </Text>
-              <Text type="p" color="grayDark">
-                Includes {migrationPreview.migrationSummary.channelCount} social channels
+                Includes {migrationPreview.migrationSummary.channelCount} social
+                channels
               </Text>
             </PriceFooterWrapper>
-
             <Button
               fullWidth
               disabled={processing}
@@ -176,12 +184,12 @@ export const Content = ({
       </SummaryContainer>
     </RightColumn>
   </Holder>
-)
+);
 
 const EssentialsPricing = ({ openModal }) => {
   const user = useUser();
-  const { data:migrationPreview, loading } = useMigrationPlanPreview(user)
-  const { migrateToOB, success, processing } = useMigrateToOB(user)
+  const { data: migrationPreview, loading } = useMigrationPlanPreview(user);
+  const { migrateToOB, success, processing } = useMigrateToOB(user);
 
   if (loading) {
     return null;
@@ -191,33 +199,35 @@ const EssentialsPricing = ({ openModal }) => {
     openModal(MODALS.upgradeSuccess, {
       cta: 'Migrate to OB Modal',
       ctaButton: 'Supercharge My Plan',
-    })
+    });
 
-    return null
+    return null;
   }
 
-  return ( <Content
-    migrationPreview={migrationPreview}
-    handleDismiss={() => {
-      openModal(MODALS.essentialsPlan, {
-        cta: 'planSelection',
-        ctaButton: 'Go back to plans',
-      });
-    }}
-    handleMigrate={() => {
-      migrateToOB(user)
-    }}
-    processing={processing}
-  />);
+  return (
+    <Content
+      migrationPreview={migrationPreview}
+      handleDismiss={() => {
+        openModal(MODALS.essentialsPlan, {
+          cta: 'planSelection',
+          ctaButton: 'Go back to plans',
+        });
+      }}
+      handleMigrate={() => {
+        migrateToOB(user);
+      }}
+      processing={processing}
+    />
+  );
 };
 
-export default function() {
-  return (<ModalContext.Consumer>
-    {({ openModal }) => (
-      <EssentialsPricing openModal={openModal} />
-    )}
-  </ModalContext.Consumer>);
-};
+export default function () {
+  return (
+    <ModalContext.Consumer>
+      {({ openModal }) => <EssentialsPricing openModal={openModal} />}
+    </ModalContext.Consumer>
+  );
+}
 
 PeriodEndString.propTypes = {
   migrationPreview: PropTypes.objectOf(PropTypes.object).isRequired,


### PR DESCRIPTION
This change removes confusion around using the word monthly when the
user is on a yearly plan

TIcket: https://buffer.atlassian.net/browse/GROW-261

Manual testing:
The below scenarios were both tested by impersonating 2 different users locally in app shell against production.

- [x]  A user who can migrate to the essentials plan and is currently on a yearly subscription:

<img width="1022" alt="Screen Shot 2021-10-11 at 9 42 55 am" src="https://user-images.githubusercontent.com/7763710/136715712-e6048513-9f44-40b3-bdb5-88dbd5093d8c.png">


- [x]  A user who can migrate to the essentials plan and is on a monthly subscription:

<img width="1097" alt="Screen Shot 2021-10-11 at 10 00 34 am" src="https://user-images.githubusercontent.com/7763710/136715699-de80668a-5185-4ed3-a374-eba37fd1ec93.png">


