### PR TITLE
append query parameters to logout redirect

### DIFF
--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -47,6 +47,10 @@ export function getProductPath(baseUrl) {
   return productPath;
 }
 
+export function getQueryParameters(baseUrl,) {
+  return baseUrl.match(/\?(?<query>.*)$/)?.groups?.query
+}
+
 function getRedirectUrl(baseUrl) {
   const productPath = getProductPath(baseUrl);
   return `https://${productPath}.buffer.com`;
@@ -56,7 +60,14 @@ export function getLogoutUrl(baseUrl = '') {
   const productPath = getProductPath(baseUrl);
   return `https://login${
     productPath.includes('local') ? '.local' : ''
-  }.buffer.com/logout?redirect=${getRedirectUrl(baseUrl)}`;
+  }.buffer.com/logout?redirect=${getRedirectUrl(baseUrl)}&${getQueryParameters(baseUrl)}`;
+}
+
+export function getLoginUrl(baseUrl = '') {
+  const productPath = getProductPath(baseUrl);
+  return `https://login${
+    productPath.includes('local') ? '.local' : ''
+  }.buffer.com/login?redirect=${getRedirectUrl(baseUrl)}&${getQueryParameters(baseUrl)}`;
 }
 
 export function getAccountUrl(baseUrl = '', user) {

--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -48,7 +48,8 @@ export function getProductPath(baseUrl) {
 }
 
 export function getQueryParameters(baseUrl,) {
-  return baseUrl.match(/\?(?<query>.*)$/)?.groups?.query
+  const query = baseUrl.match(/\?(?<query>.*)$/)?.groups?.query
+  return query ? `&${encodeURI(query)}` : ''
 }
 
 function getRedirectUrl(baseUrl) {
@@ -60,14 +61,14 @@ export function getLogoutUrl(baseUrl = '') {
   const productPath = getProductPath(baseUrl);
   return `https://login${
     productPath.includes('local') ? '.local' : ''
-  }.buffer.com/logout?redirect=${getRedirectUrl(baseUrl)}&${getQueryParameters(baseUrl)}`;
+  }.buffer.com/logout?redirect=${getRedirectUrl(baseUrl)}${getQueryParameters(baseUrl)}`;
 }
 
 export function getLoginUrl(baseUrl = '') {
   const productPath = getProductPath(baseUrl);
   return `https://login${
     productPath.includes('local') ? '.local' : ''
-  }.buffer.com/login?redirect=${getRedirectUrl(baseUrl)}&${getQueryParameters(baseUrl)}`;
+  }.buffer.com/login?redirect=${getRedirectUrl(baseUrl)}${getQueryParameters(baseUrl)}`;
 }
 
 export function getAccountUrl(baseUrl = '', user) {

--- a/packages/app-shell/src/components/NavBar/index.test.js
+++ b/packages/app-shell/src/components/NavBar/index.test.js
@@ -1,0 +1,22 @@
+import { getQueryParameters, getLoginUrl } from './index'
+
+describe('NavBar', () => {
+  describe('getQueryParameters', () => {
+    it('return undefined if no query parameters', () => {
+      const params = getQueryParameters('http://buffer.com')
+      expect(params).toBeUndefined()
+    })
+    it('return all query parameters', () => {
+      const params = getQueryParameters('http://buffer.com?foo=foo&bar=bar')
+      expect(params).toEqual('foo=foo&bar=bar')
+    })
+  })
+
+  describe('getLoginUrl', () => {
+    it('return a valid login url', () => {
+      const url = getLoginUrl('http://publish.buffer.com?foo=foo&var=bar')
+      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com&foo=foo&var=bar')
+    })
+  })
+})
+

--- a/packages/app-shell/src/components/NavBar/index.test.js
+++ b/packages/app-shell/src/components/NavBar/index.test.js
@@ -2,20 +2,25 @@ import { getQueryParameters, getLoginUrl } from './index'
 
 describe('NavBar', () => {
   describe('getQueryParameters', () => {
-    it('return undefined if no query parameters', () => {
+    it('return an empty strin if no query parameters', () => {
       const params = getQueryParameters('http://buffer.com')
-      expect(params).toBeUndefined()
+      expect(params).toEqual('')
     })
     it('return all query parameters', () => {
       const params = getQueryParameters('http://buffer.com?foo=foo&bar=bar')
-      expect(params).toEqual('foo=foo&bar=bar')
+      expect(params).toEqual('&foo=foo&bar=bar')
     })
   })
 
   describe('getLoginUrl', () => {
     it('return a valid login url', () => {
-      const url = getLoginUrl('http://publish.buffer.com?foo=foo&var=bar')
-      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com&foo=foo&var=bar')
+      const url = getLoginUrl('http://publish.buffer.com')
+      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com')
+    })
+
+    it('return a valid login url with params in the redirect url', () => {
+      const url = getLoginUrl('http://publish.buffer.com?foo=foo&bar=bar')
+      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com&foo=foo&bar=bar')
     })
   })
 })

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -10,7 +10,7 @@ import {
 } from '@apollo/client';
 import ReactDOM from 'react-dom';
 
-import NavBar, { getLogoutUrl } from '../../components/NavBar';
+import NavBar, { getLoginUrl } from '../../components/NavBar';
 import Banner from '../../components/Banner';
 import Modal from '../../components/Modal/index';
 import { UserContext } from '../../common/context/User';
@@ -63,7 +63,7 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
   if (
     networkErrors?.some((err) => err.extensions?.code === 'UNAUTHENTICATED')
   ) {
-    window.location.assign(getLogoutUrl(window.location.href));
+    window.location.assign(getLoginUrl(window.location.href));
   }
 
   const modal = useModal();


### PR DESCRIPTION
This ensures that any query parameters are properly passed down to the redirect URL for users without an active session.

You can test this out in here https://fix-logout-redirect-appshell.dev.buffer.com/?foo=foo&bar=bar

## Notes: 
- This is a follow-up to the work started in https://github.com/bufferapp/buffer-publish/pull/1761.
- This issue was reported by @mallen5311 via Slack: https://buffer.slack.com/archives/CHRPK6R6D/p1617728115071500
- This is passing down the parameters to the login service, but those are getting stripped down when logging in, so we will need additional work if we want to persist those parameters after the login.
