### PR TITLE
[TOOLS-156] Live Chat Experiment

### DIFF
--- a/packages/app-shell/src/components/NavBar/utils/dropdown-items.js
+++ b/packages/app-shell/src/components/NavBar/utils/dropdown-items.js
@@ -2,23 +2,18 @@ function getHelpDropdownItems() {
   return [
     {
       id: 'Help Center',
-      title: 'Visit Help Center',
-      onItemClick: () => {
-        window.open(
-          'https://support.buffer.com/hc/en-us/?utm_source=app&utm_medium=appshell&utm_campaign=appshell',
-          '_blank'
-        );
-      },
-    },
-    {
-      id: 'Quick Help',
-      title: 'Quick Help',
+      title: 'Help Center',
       onItemClick: () => {
         if (window.zE) {
           window.zE('webWidget', 'show');
           window.zE('webWidget', 'open');
         }
       },
+    },
+    {
+      id: 'Live Chat',
+      title: 'Live Chat',
+      onItemClick: () => {}, // Will open Pendo popup through classname
     },
     {
       id: 'Status',


### PR DESCRIPTION
Advocacy is conducting a two-week experiment in which we change the Navigator's "Help" menu items and show a survey for any customers interested in Live Chat. The Live Chat survey is triggered by our Pendo integration, which targets the class for the Live Chat menu item. 

https://buffer.atlassian.net/browse/TOOLS-156

**Changes**
- Remove `Visit Help Center` menu item
- Rename `Quick Help` menu item to `Help Center`
- Add `Live Chat` menu item

**Demo**
![Peek 2021-10-28 17-27](https://user-images.githubusercontent.com/16836517/139297517-8362b45d-45c7-45f9-a5c8-6b2217d5e150.gif)

**Note**
The Pendo survey won't appear in the branch deploy for this PR, as Pendo is not installed in our staging environment. If you need to test the full flow (don't feel you have to), you'll need access to Pendo. Reach out to #help-tools or #prod-core-tools in Slack for access. Once you have access, you can follow the directions I've shared [here](https://buffer.slack.com/archives/C4A3W2LKY/p1635438119099600) to preview the survey.