### PR TITLE
[TOOLS-187] Remove Live Chat Experiment

### DIFF
--- a/packages/app-shell/src/components/NavBar/utils/dropdown-items.js
+++ b/packages/app-shell/src/components/NavBar/utils/dropdown-items.js
@@ -2,18 +2,23 @@ function getHelpDropdownItems() {
   return [
     {
       id: 'Help Center',
-      title: 'Help Center',
+      title: 'Visit Help Center',
+      onItemClick: () => {
+        window.open(
+          'https://support.buffer.com/hc/en-us/?utm_source=app&utm_medium=appshell&utm_campaign=appshell',
+          '_blank'
+        );
+      },
+    },
+    {
+      id: 'Quick Help',
+      title: 'Quick Help',
       onItemClick: () => {
         if (window.zE) {
           window.zE('webWidget', 'show');
           window.zE('webWidget', 'open');
         }
       },
-    },
-    {
-      id: 'Live Chat',
-      title: 'Live Chat',
-      onItemClick: () => {}, // Will open Pendo popup through classname
     },
     {
       id: 'Status',


### PR DESCRIPTION
Reverts bufferapp/app-shell#129

The live chat experiment is ending on Wednesday, November 17th, so we should revert the App Shell back to its previous state.

[Jira ticket](https://buffer.atlassian.net/browse/TOOLS-187)