### PR TITLE
[GROW-306] extract trial banner copy to a function

### DIFF
--- a/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.jsx
+++ b/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const getTrialBannerCopy = ({ planName, daysRemaining }) => {
+
+    let planNameText = planName
+    if (planName === 'Essentials + Team Pack') {
+        planNameText = 'Essentials plan with Team pack'
+    } else {
+        planNameText = `${planName} plan`
+    }
+    return `You are on the ${planNameText} trial with ${daysRemaining} ${
+        daysRemaining === 1 ? 'day' : 'days'
+      } left. Add your billing details now to start your subscription.`;
+};
+
+export default getTrialBannerCopy;

--- a/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.jsx
+++ b/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const getTrialBannerCopy = ({ planName, daysRemaining }) => {
 
     let planNameText = planName

--- a/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.test.jsx
+++ b/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.test.jsx
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react-hooks';
+import getTrialBannerCopy from './getTrialBannerCopy';
+
+describe('getTrialBannerCopy', () => {
+  it('should the correct trail banner copy', () => {
+    expect(getTrialBannerCopy({ planName: 'Essentials + Team Pack', daysRemaining: 1 })).toBe('You are on the Essentials plan with Team pack trial with 1 day left. Add your billing details now to start your subscription.');
+    expect(getTrialBannerCopy({ planName: 'Essentials + Team Pack', daysRemaining: 13 })).toBe('You are on the Essentials plan with Team pack trial with 13 days left. Add your billing details now to start your subscription.');
+    expect(getTrialBannerCopy({ planName: 'Essentials', daysRemaining: 10 })).toBe('You are on the Essentials plan trial with 10 days left. Add your billing details now to start your subscription.');
+    expect(getTrialBannerCopy({ planName: 'Agency', daysRemaining: 10 })).toBe('You are on the Agency plan trial with 10 days left. Add your billing details now to start your subscription.');
+    });
+});

--- a/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.test.jsx
+++ b/packages/app-shell/src/exports/Navigator/getTrialBannerCopy.test.jsx
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks';
 import getTrialBannerCopy from './getTrialBannerCopy';
 
 describe('getTrialBannerCopy', () => {

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -18,6 +18,7 @@ import { ModalContext } from '../../common/context/Modal';
 import useModal, { MODALS } from '../../common/hooks/useModal';
 import { QUERY_ACCOUNT } from '../../common/graphql/account';
 import useUserTracker from '../../common/hooks/useUserTracker';
+import getTrialBannerCopy from './getTrialBannerCopy';
 
 function getActiveProductFromUrl() {
   const productUrl = window.location.hostname.split('.')[0];
@@ -68,6 +69,7 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
 
   const modal = useModal();
 
+
   let isActiveTrial;
   let trialBannerString;
   //in human: is OB, is admin, doesn't have payment details
@@ -83,11 +85,10 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
         user.currentOrganization?.billing?.subscription?.plan?.name;
       const daysRemaining =
         user.currentOrganization?.billing?.subscription?.trial?.remainingDays;
-      trialBannerString = `You are on the Essentials plan ${
-        planName === 'Essentials' ? '' : 'with Team Pack'
-      } trial with ${daysRemaining} ${
-        daysRemaining === 1 ? 'day' : 'days'
-      } left. Add your billing details now to start your subscription.`;
+      trialBannerString = getTrialBannerCopy({
+        planName,
+        daysRemaining
+      })
     }
   }
 


### PR DESCRIPTION
Extracted the copy to a function and added a test.

The `planName` is coming from here: 
https://github.com/bufferapp/core-authentication-service/blob/bbe172d413aa32ac744effc155665e3b0f9bd332/shared/services/billing/interfaces.ts#L23-L28

Tested locally:
<img width="1609" alt="Screen Shot 2021-12-09 at 12 11 20 PM" src="https://user-images.githubusercontent.com/1514227/145386127-1220bde8-2326-440a-a415-3c11027d78db.png">

