### PR TITLE
[UPDATE] When on trial click start sub default

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.test.jsx
@@ -22,8 +22,13 @@ describe('useSelectedPlan', () => {
   });
 
   it('should set the default as the essentials plan if the intent is to upgrade', () => {
+    const planOptionsForUpgrade = [
+      { planId: 'essentials', isCurrentPlan: false, planInterval: 'year' },
+      { planId: 'team', isCurrentPlan: false, planInterval: 'year' },
+      { planId: 'free', planInterval: 'month' },
+    ];
     const { result } = renderHook(() =>
-      useSelectedPlan(planOptions, true, user)
+      useSelectedPlan(planOptionsForUpgrade, true, user)
     );
     expect(result.current.selectedPlan.planId).toBe('essentials');
   });

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -56,7 +56,8 @@ export function getDefaultSelectedPlan(planOptions, user, isUpgradeIntent) {
   const planOptionsExcludingFree = filterListOfPlans(planOptions, 'free');
   const plans = featureFilpAgencyPlan ? planOptionsExcludingFree : planOptions;
 
-  const defaultSelectedPlan = isOnFreePlan ? plans[0] : currentPlan;
+  const defaultSelectedPlan =
+    isOnFreePlan && !currentPlan ? plans[0] : currentPlan;
 
   return defaultSelectedPlan;
 }

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -200,10 +200,10 @@ describe('Modal - utils', () => {
       });
     });
 
-    it("should set the default selected plan to the first plan in list when it's a free plan", () => {
+    it("should set the default selected plan to the first plan in list when it's a free plan AND there is no current plan available", () => {
       const planOptions = [
-        { planId: 'free', planInterval: 'month', isCurrentPlan: true },
-        ...listOfFilteredPlanOptions,
+        { planId: 'free', planInterval: 'month', isCurrentPlan: false },
+        ...listOfPlanOptionsWithNoCurrentPlan,
       ];
 
       const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
@@ -215,10 +215,10 @@ describe('Modal - utils', () => {
       });
     });
 
-    it('should set the default selected plan to the first plan in list when isUpgradeIntent is true', () => {
+    it('should set the default selected plan to the first plan in list when isUpgradeIntent is true AND there is no current plan available', () => {
       const planOptions = [
-        { planId: 'free', planInterval: 'month', isCurrentPlan: true },
-        ...listOfFilteredPlanOptions,
+        { planId: 'free', planInterval: 'month', isCurrentPlan: false },
+        ...listOfPlanOptionsWithNoCurrentPlan,
       ];
 
       const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
@@ -230,7 +230,7 @@ describe('Modal - utils', () => {
       });
     });
 
-    it('should set the default selected plan to the first plan in list when the is no plan in the list of options with isCurrentPlan set to true', () => {
+    it('should set the default selected plan to the first plan in list when there is no plan in the list of options with isCurrentPlan set to true', () => {
       const planOptions = [...listOfPlanOptionsWithNoCurrentPlan];
 
       const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
@@ -239,6 +239,18 @@ describe('Modal - utils', () => {
         planId: 'essentials',
         planInterval: 'month',
         isCurrentPlan: false,
+      });
+    });
+
+    it('should set the default selected plan to the current plan when isUpgradeIntent and there is a current plan available in list ', () => {
+      const planOptions = [...listOfFilteredPlanOptions];
+
+      const result = getDefaultSelectedPlan(planOptions, user, true);
+
+      expect(result).toEqual({
+        planId: 'team',
+        planInterval: 'year',
+        isCurrentPlan: true,
       });
     });
   });


### PR DESCRIPTION
This now pre-selects the trial plan when opening the plan selector modal.

Testing instructions:
1. Make sure the user your using is on a trial
2. Click the "Strat subscription" button in the banner (see image 1 for ref)
3. The plan selector modal should open and the plan which you are trialing out should now be selected by default.

**What was happening before this change?**
When a user would click that "Start subscription" button the modal would open and pre-select the essentials plan as default.

1. Start subscription button
![Screen Shot 2022-01-20 at 3 25 50 pm](https://user-images.githubusercontent.com/7763710/150273357-8815c0d6-8de5-462e-a040-ed2b09fc26bc.png)


Video showing what we're fixing, the working code, and a brief explanation of some of the code 🙂
https://www.loom.com/share/e61ebd27eccf41faa3321db2b2f7c5d3