### PR TITLE
[GROW-177] Do not remove the modal hash from the URL and return it to login redirect

### DIFF
--- a/packages/app-shell/src/common/hooks/useModal.js
+++ b/packages/app-shell/src/common/hooks/useModal.js
@@ -46,7 +46,6 @@ function useModal() {
       (k) => k === hash.replace('#', '')
     );
     if (matchingModal) {
-      window.location.hash = '';
       setModal(matchingModal);
     }
   }, []);

--- a/packages/app-shell/src/common/hooks/useModal.test.js
+++ b/packages/app-shell/src/common/hooks/useModal.test.js
@@ -1,68 +1,59 @@
-import useModal, { MODALS } from './useModal'
-import { renderHook, act } from '@testing-library/react-hooks'
+import { renderHook, act } from '@testing-library/react-hooks';
+import useModal, { MODALS } from './useModal';
 
 describe('useModal', () => {
   beforeEach(() => {
-      window.history.pushState({}, '', '');
-  })
+    window.history.pushState({}, '', '');
+  });
 
   describe('read modal from hash parameters', () => {
     it('return null if no hash param', () => {
-      const { result } = renderHook(() => useModal())
-      const { modal } = result.current
-      expect(modal).toBeNull()
-    })
+      const { result } = renderHook(() => useModal());
+      const { modal } = result.current;
+      expect(modal).toBeNull();
+    });
 
     it('return a valid modal from hash parameters', () => {
-
       window.history.pushState({}, '', '#paymentMethod');
-      const { result } = renderHook(() => useModal())
-      const { modal } = result.current
-      expect(modal).toEqual(MODALS.paymentMethod)
-    })
+      const { result } = renderHook(() => useModal());
+      const { modal } = result.current;
+      expect(modal).toEqual(MODALS.paymentMethod);
+    });
 
     it('return null if hash does not match', () => {
-
       window.history.pushState({}, '', '#fooBarBaz');
-      const { result } = renderHook(() => useModal())
-      const { modal } = result.current
-      expect(modal).toBeNull()
-    })
-
-    it('clean up query parameters after reading the modal', () => {
-
-      window.history.pushState({}, '', '#paymentMethod');
-      const { result } = renderHook(() => useModal())
-      expect(window.location.hash).toEqual("")
-    })
-  })
+      const { result } = renderHook(() => useModal());
+      const { modal } = result.current;
+      expect(modal).toBeNull();
+    });
+  });
 
   describe('update the modal', () => {
     it('does not set an undefined modal', () => {
-      const { result } = renderHook(() => useModal())
+      const { result } = renderHook(() => useModal());
       act(() => {
-        result.current.openModal('foo')
-      })
-      expect(result.current.modal).toBeNull()
-    })
+        result.current.openModal('foo');
+      });
+      expect(result.current.modal).toBeNull();
+    });
 
     it('set a modal', () => {
-      const { result } = renderHook(() => useModal())
+      const { result } = renderHook(() => useModal());
       act(() => {
-        result.current.openModal(MODALS.planSelector)
-      })
+        result.current.openModal(MODALS.planSelector);
+      });
 
-      expect(result.current.modal).toEqual(MODALS.planSelector)
-    })
+      expect(result.current.modal).toEqual(MODALS.planSelector);
+    });
 
     it('set a modal with data', () => {
-      const { result } = renderHook(() => useModal())
-      const data = { foo: 'bar' }
+      const { result } = renderHook(() => useModal());
+      const data = { foo: 'bar' };
       act(() => {
-        result.current.openModal(MODALS.planSelector, data)
-      })
+        result.current.openModal(MODALS.planSelector, data);
+      });
 
-      expect(result.current.data).toEqual(data)
-    })
-  })
-})
+      expect(result.current.data).toEqual(data);
+    });
+  });
+});

--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -47,9 +47,11 @@ export function getProductPath(baseUrl) {
   return productPath;
 }
 
-export function getQueryParameters(baseUrl,) {
-  const query = baseUrl.match(/\?(?<query>.*)$/)?.groups?.query
-  return query ? `&${encodeURI(query)}` : ''
+export function getQueryParameters(baseUrl) {
+  const query = baseUrl.match(/\?(?<query>.*)$/)?.groups?.query;
+  // NOTE: returned with a starting "&", because it is always used after the
+  // initial query parameter, "?redirect="
+  return query ? `&${encodeURI(query)}` : '';
 }
 
 function getRedirectUrl(baseUrl) {
@@ -57,18 +59,28 @@ function getRedirectUrl(baseUrl) {
   return `https://${productPath}.buffer.com`;
 }
 
-export function getLogoutUrl(baseUrl = '') {
-  const productPath = getProductPath(baseUrl);
-  return `https://login${
-    productPath.includes('local') ? '.local' : ''
-  }.buffer.com/logout?redirect=${getRedirectUrl(baseUrl)}${getQueryParameters(baseUrl)}`;
+function getRedirectUrlWithParams(baseUrl) {
+  return `${getRedirectUrl(baseUrl)}${getQueryParameters(baseUrl)}${encodeURI(
+    window.location.hash
+  )}`;
 }
 
-export function getLoginUrl(baseUrl = '') {
+function getLoginOrLogoutUrl(baseUrl = '', loginOrLogoutPath) {
   const productPath = getProductPath(baseUrl);
-  return `https://login${
+  const result = `https://login${
     productPath.includes('local') ? '.local' : ''
-  }.buffer.com/login?redirect=${getRedirectUrl(baseUrl)}${getQueryParameters(baseUrl)}`;
+  }.buffer.com/${loginOrLogoutPath}?redirect=${getRedirectUrlWithParams(
+    baseUrl
+  )}`;
+  return result;
+}
+
+export function getLogoutUrl(baseUrl) {
+  return getLoginOrLogoutUrl(baseUrl, 'logout');
+}
+
+export function getLoginUrl(baseUrl) {
+  return getLoginOrLogoutUrl(baseUrl, 'login');
 }
 
 export function getAccountUrl(baseUrl = '', user) {

--- a/packages/app-shell/src/components/NavBar/index.test.js
+++ b/packages/app-shell/src/components/NavBar/index.test.js
@@ -1,27 +1,67 @@
-import { getQueryParameters, getLoginUrl } from './index'
+import { getQueryParameters, getLoginUrl, getLogoutUrl } from './index';
 
 describe('NavBar', () => {
   describe('getQueryParameters', () => {
     it('return an empty strin if no query parameters', () => {
-      const params = getQueryParameters('http://buffer.com')
-      expect(params).toEqual('')
-    })
+      const params = getQueryParameters('http://buffer.com');
+      expect(params).toEqual('');
+    });
+
     it('return all query parameters', () => {
-      const params = getQueryParameters('http://buffer.com?foo=foo&bar=bar')
-      expect(params).toEqual('&foo=foo&bar=bar')
-    })
-  })
+      const params = getQueryParameters('http://buffer.com?foo=foo&bar=bar');
+      expect(params).toEqual('&foo=foo&bar=bar');
+    });
+  });
 
   describe('getLoginUrl', () => {
+    afterEach(() => {
+      window.location.hash = '';
+    });
+
     it('return a valid login url', () => {
-      const url = getLoginUrl('http://publish.buffer.com')
-      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com')
-    })
+      const url = getLoginUrl('http://publish.buffer.com');
+      expect(url).toEqual(
+        'https://login.buffer.com/login?redirect=https://publish.buffer.com'
+      );
+    });
 
     it('return a valid login url with params in the redirect url', () => {
-      const url = getLoginUrl('http://publish.buffer.com?foo=foo&bar=bar')
-      expect(url).toEqual('https://login.buffer.com/login?redirect=https://publish.buffer.com&foo=foo&bar=bar')
-    })
-  })
-})
+      const url = getLoginUrl('http://publish.buffer.com?foo=foo&bar=bar');
+      expect(url).toEqual(
+        'https://login.buffer.com/login?redirect=https://publish.buffer.com&foo=foo&bar=bar'
+      );
+    });
 
+    it('return a valid login url with a hash in the redirect url', () => {
+      window.location.hash = '#planSelector';
+      const url = getLoginUrl('https://account.buffer.com#planSelector');
+      expect(url).toEqual(
+        'https://login.buffer.com/login?redirect=https://account.buffer.com#planSelector'
+      );
+    });
+  });
+
+  describe('getLogoutUrl', () => {
+    it('return a valid logout url', () => {
+      const url = getLogoutUrl('http://publish.buffer.com');
+      expect(url).toEqual(
+        'https://login.buffer.com/logout?redirect=https://publish.buffer.com'
+      );
+    });
+
+    it('return a valid logout url with params in the redirect url', () => {
+      const url = getLogoutUrl('http://publish.buffer.com?foo=foo&bar=bar');
+      expect(url).toEqual(
+        'https://login.buffer.com/logout?redirect=https://publish.buffer.com&foo=foo&bar=bar'
+      );
+    });
+
+    it('return a valid logout url with a hash in the redirect url', () => {
+      window.location.hash = '#planSelector';
+      const url = getLogoutUrl('https://account.buffer.com#planSelector');
+      expect(url).toEqual(
+        'https://login.buffer.com/logout?redirect=https://account.buffer.com#planSelector'
+      );
+    });
+  });
+});


### PR DESCRIPTION
We have some hashes that we can use in the buffer URLs which will trigger the Plan Selector and the Plan Migrator modal. Those are often used by customer advocates in order to provide a link to the users that they can use to self upgrade/downgrade or migrate. 
When a user is not authenticated we redirect them to the login service, which receives the current URL slightly modified (and verified) as a redirect URL. 
So far by trimming the hash from the URL, we were preventing the modal to open after the user have logged in successfully. 

This requires a small change in the account app as well since it overrides the redirect of the app shell. 

https://buffer.atlassian.net/browse/GROW-177


NOTE: Most of the changes are prettier formatting. The actual code changes are in packages/app-shell/src/common/hooks/useModal.js
and packages/app-shell/src/components/NavBar/index.jsx