### PR TITLE
Clean the account-app menu item url

### DIFF
--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -83,17 +83,16 @@ export function getLoginUrl(baseUrl) {
   return getLoginOrLogoutUrl(baseUrl, 'login');
 }
 
-export function getAccountUrl(baseUrl = '', user) {
-  return `https://account.buffer.com?redirect=${getRedirectUrl(
-    baseUrl
-  )}&username=${encodeURI(user.name)}`;
-}
-
 function getUrlEnvModifier() {
   const [, envModifier] = window.location.hostname.match(
     /\w+\.(\w+\.)buffer\.com/
   ) || [null, null];
   return envModifier;
+}
+
+export function getAccountUrl() {
+  const envModifier = getUrlEnvModifier();
+  return `https://account.${envModifier || ''}buffer.com/`;
 }
 
 export function getBillingUrl() {
@@ -353,7 +352,7 @@ const NavBar = React.memo((props) => {
                   hasDivider: organizations.length > 1,
                   onItemClick: () => {
                     window.location.assign(
-                      getAccountUrl(window.location.href, user)
+                      getAccountUrl()
                     );
                   },
                 },


### PR DESCRIPTION
While testing the redirect changes I introduced in a previous PR (https://github.com/bufferapp/app-shell/pull/144), I noticed that the account menu item is passing a username and a redirect parameter that to my understanding does not seem useful. Additionally, it has the potential to create a bit weird recursive redirect URLs, like the following.
`https://account.buffer.com/?redirect=https://account.buffer.com/?redirect=https://account.buffer.com/?redirect=https://analyze.buffer.com&username=undefined`

The above is the result of consecutive clicks on the account menu item. 
