### PR TITLE
Task/grow 389 fix upgrade bug

### DIFF
--- a/cypress/fixtures/accountObFreeUpgrade.json
+++ b/cypress/fixtures/accountObFreeUpgrade.json
@@ -1,0 +1,629 @@
+{
+   "data":{
+      "account":{
+         "id":"606b65d6dad38c9d20b70792",
+         "email":"ob_free@buffer.com",
+         "createdAt":"2021-04-05T19:32:38.841Z",
+         "featureFlips":[
+            "grantAnalyzeAccess",
+            "sharedChannels",
+            "engageRollOut",
+            "geid1_free_user_trial_prompt"
+         ],
+         "isImpersonation":false,
+         "currentOrganization":{
+            "id":"606b65d6dad38c03d2b70793",
+            "name":"test",
+            "canEdit":true,
+            "role":"admin",
+            "canMigrateToOneBuffer": {
+               "canMigrate": false,
+               "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
+               "__typename": "CanMigrateToOneBuffer"
+            },
+            "createdAt":"2021-04-05T19:32:38.961Z",
+            "isOneBufferOrganization":true,
+            "shouldDisplayInviteCTA":false,
+            "featureFlips":[
+               "grantAnalyzeAccess",
+               "sharedChannels",
+               "engageRollOut",
+               "geid1_free_user_trial_prompt"
+            ],
+            "channels":[
+              {
+                "id":"606b65e1dd934f70840bfef7",
+                "__typename":"Channel"
+              }
+            ],
+            "billing":{
+               "id":"606b65d6dad38c03d2b70793",
+               "canAccessAnalytics":false,
+               "canAccessEngagement":false,
+               "canAccessPublishing":true,
+               "paymentDetails":{
+                  "hasPaymentDetails":true,
+                  "__typename":"PaymentDetails"
+               },
+               "canStartTrial":false,
+               "subscription":{
+                  "quantity": 1,
+                  "interval":"month",
+                  "periodEnd":null,
+                  "isCanceledAtPeriodEnd":false,
+                  "trial":{
+                     "endDate": "2022-02-01T05:06:44.000Z",
+                     "isActive": false,
+                     "isAwaitingUserAction": true,
+                     "remainingDays": 0,
+                     "startDate": "2022-01-18T05:06:44.000Z",
+                     "__typename": "Trial"
+                  },
+                  "plan":{
+                     "id":"free",
+                     "name":"Free",
+                     "__typename":"OBPlan"
+                  },
+                  "__typename":"OBSubscription"
+               },
+               "changePlanOptions":[
+                  {
+                     "planId":"free",
+                     "planName":"Free",
+                     "planInterval":"month",
+                     "channelsQuantity":1,
+                     "description":"Simplify the noise and test out social media management tools.",
+                     "isCurrentPlan":true,
+                     "highlights":[
+                        "Basic publishing tools",
+                        "Limited usage"
+                     ],
+                     "currency":"$",
+                     "basePrice":0,
+                     "totalPrice":0,
+                     "discountPercentage":0,
+                     "discountNote":"",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"",
+                     "summary":{
+                        "details":[
+                           "10 scheduled posts",
+                           "3 social channels",
+                           "One user"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":false,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  },
+                  {
+                     "planId":"essentials",
+                     "planName":"Essentials",
+                     "planInterval":"month",
+                     "channelsQuantity":1,
+                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
+                     "isCurrentPlan":false,
+                     "highlights":[
+                        "Advanced publishing tools",
+                        "Analytics & reporting",
+                        "Engagement tools"
+                     ],
+                     "currency":"$",
+                     "basePrice":6,
+                     "totalPrice":6,
+                     "discountPercentage":0,
+                     "discountNote":"",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"Save $12/year",
+                     "summary":{
+                        "details":[
+                           "Unlimited scheduled posts",
+                           "Unlimited social channels",
+                           "One user"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":false,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  },
+                  {
+                     "planId":"team",
+                     "planName":"Essentials + Team Pack",
+                     "planInterval":"month",
+                     "channelsQuantity":1,
+                     "description":"Collaborate with your team in one place & save time reporting.",
+                     "isCurrentPlan":false,
+                     "highlights":[
+                        "Advanced publishing tools",
+                        "Analytics & reporting",
+                        "Engagement tools",
+                        "Unlimited team members & clients",
+                        "Drafting & approval workflow tools",
+                        "Exportable PDF reports"
+                     ],
+                     "currency":"$",
+                     "basePrice":12,
+                     "totalPrice":12,
+                     "discountPercentage":0,
+                     "discountNote":"",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"Save $24/year",
+                     "summary":{
+                        "details":[
+                           "Unlimited scheduled posts",
+                           "Unlimited social channels",
+                           "Unlimited users"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":true,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  },
+                  {
+                     "planId":"free",
+                     "planName":"Free",
+                     "planInterval":"year",
+                     "channelsQuantity":1,
+                     "description":"Simplify the noise and test out social media management tools.",
+                     "isCurrentPlan":true,
+                     "highlights":[
+                        "Basic publishing tools",
+                        "Limited usage"
+                     ],
+                     "currency":"$",
+                     "basePrice":0,
+                     "totalPrice":0,
+                     "discountPercentage":0,
+                     "discountNote":"0% Discount",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"",
+                     "summary":{
+                        "details":[
+                           "10 scheduled posts",
+                           "3 social channels",
+                           "One user"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":false,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  },
+                  {
+                     "planId":"essentials",
+                     "planName":"Essentials",
+                     "planInterval":"year",
+                     "channelsQuantity":1,
+                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
+                     "isCurrentPlan":false,
+                     "highlights":[
+                        "Advanced publishing tools",
+                        "Analytics & reporting",
+                        "Engagement tools"
+                     ],
+                     "currency":"$",
+                     "basePrice":5,
+                     "totalPrice":60,
+                     "discountPercentage":17,
+                     "discountNote":"17% Discount",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"Saving $12/year",
+                     "summary":{
+                        "details":[
+                           "Unlimited scheduled posts",
+                           "Unlimited social channels",
+                           "One user"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":false,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  },
+                  {
+                     "planId":"team",
+                     "planName":"Essentials + Team Pack",
+                     "planInterval":"year",
+                     "channelsQuantity":1,
+                     "description":"Collaborate with your team in one place & save time reporting.",
+                     "isCurrentPlan":false,
+                     "highlights":[
+                        "Advanced publishing tools",
+                        "Analytics & reporting",
+                        "Engagement tools",
+                        "Unlimited team members & clients",
+                        "Drafting & approval workflow tools",
+                        "Exportable PDF reports"
+                     ],
+                     "currency":"$",
+                     "basePrice":10,
+                     "totalPrice":120,
+                     "discountPercentage":17,
+                     "discountNote":"17% Discount",
+                     "priceNote":"Per social channel per month",
+                     "absoluteSavings":"Saving $24/year",
+                     "summary":{
+                        "details":[
+                           "Unlimited scheduled posts",
+                           "Unlimited social channels",
+                           "Unlimited users"
+                        ],
+                        "__typename":"OBPlanOptionSummary"
+                     },
+                     "isRecommended":true,
+                     "downgradedMessage":"",
+                     "channelSlotDetails":{
+                        "flatFee":0, 
+                        "currentQuantity":0, 
+                        "chargableQuantity":0, 
+                        "pricePerQuantity":0, 
+                        "minimumQuantity":0,
+                        "__typename": "ChannelSlotDetails"
+                     },
+                     "__typename":"OBPlanOption"
+                  }
+               ],
+               "__typename":"OBBilling"
+            },
+            "__typename":"AccountOrganization"
+         },
+         "organizations":[
+            {
+               "id":"606b65d6dad38c03d2b70793",
+               "name":"test",
+               "canEdit":true,
+               "role":"admin",
+               "canMigrateToOneBuffer": {
+                  "canMigrate": false,
+                  "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
+                  "__typename": "CanMigrateToOneBuffer"
+               },
+               "createdAt":"2021-04-05T19:32:38.961Z",
+               "isOneBufferOrganization":true,
+               "shouldDisplayInviteCTA":false,
+               "featureFlips":[
+                  "grantAnalyzeAccess",
+                  "sharedChannels",
+                  "engageRollOut"
+               ],
+               "channels":[
+                  {
+                     "id":"606b65e1dd934f70840bfef7",
+                     "name":"testing public",
+                     "service":"facebook",
+                     "organizationId":"606b65d6dad38c03d2b70793",
+                     "__typename":"Channel"
+                  }
+               ],
+               "billing":{
+                  "id":"606b65d6dad38c03d2b70793",
+                  "canAccessAnalytics":false,
+                  "canAccessEngagement":false,
+                  "canAccessPublishing":true,
+                  "paymentDetails":{
+                     "hasPaymentDetails":true,
+                     "__typename":"PaymentDetails"
+                  },
+                  "canStartTrial":false,
+                  "subscription":{
+                     "quantity":1,
+                     "interval":"month",
+                     "periodEnd":null,
+                     "isCanceledAtPeriodEnd":false,
+                     "trial":null,
+                     "plan":{
+                        "id":"free",
+                        "name":"Free",
+                        "__typename":"OBPlan"
+                     },
+                     "__typename":"OBSubscription"
+                  },
+                  "changePlanOptions":[
+                     {
+                        "planId":"free",
+                        "planName":"Free",
+                        "planInterval":"month",
+                        "channelsQuantity":1,
+                        "description":"Simplify the noise and test out social media management tools.",
+                        "isCurrentPlan":true,
+                        "highlights":[
+                           "Basic publishing tools",
+                           "Limited usage"
+                        ],
+                        "currency":"$",
+                        "basePrice":0,
+                        "totalPrice":0,
+                        "discountPercentage":0,
+                        "discountNote":"",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"",
+                        "summary":{
+                           "details":[
+                              "10 scheduled posts",
+                              "3 social channels",
+                              "One user"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":false,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     },
+                     {
+                        "planId":"essentials",
+                        "planName":"Essentials",
+                        "planInterval":"month",
+                        "channelsQuantity":1,
+                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
+                        "isCurrentPlan":false,
+                        "highlights":[
+                           "Advanced publishing tools",
+                           "Analytics & reporting",
+                           "Engagement tools"
+                        ],
+                        "currency":"$",
+                        "basePrice":6,
+                        "totalPrice":6,
+                        "discountPercentage":0,
+                        "discountNote":"",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"Save $12/year",
+                        "summary":{
+                           "details":[
+                              "Unlimited scheduled posts",
+                              "Unlimited social channels",
+                              "One user"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":false,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     },
+                     {
+                        "planId":"team",
+                        "planName":"Essentials + Team Pack",
+                        "planInterval":"month",
+                        "channelsQuantity":1,
+                        "description":"Collaborate with your team in one place & save time reporting.",
+                        "isCurrentPlan":false,
+                        "highlights":[
+                           "Advanced publishing tools",
+                           "Analytics & reporting",
+                           "Engagement tools",
+                           "Unlimited team members & clients",
+                           "Drafting & approval workflow tools",
+                           "Exportable PDF reports"
+                        ],
+                        "currency":"$",
+                        "basePrice":12,
+                        "totalPrice":12,
+                        "discountPercentage":0,
+                        "discountNote":"",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"Save $24/year",
+                        "summary":{
+                           "details":[
+                              "Unlimited scheduled posts",
+                              "Unlimited social channels",
+                              "Unlimited users"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":true,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     },
+                     {
+                        "planId":"free",
+                        "planName":"Free",
+                        "planInterval":"year",
+                        "channelsQuantity":1,
+                        "description":"Simplify the noise and test out social media management tools.",
+                        "isCurrentPlan":true,
+                        "highlights":[
+                           "Basic publishing tools",
+                           "Limited usage"
+                        ],
+                        "currency":"$",
+                        "basePrice":0,
+                        "totalPrice":0,
+                        "discountPercentage":0,
+                        "discountNote":"0% Discount",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"",
+                        "summary":{
+                           "details":[
+                              "10 scheduled posts",
+                              "3 social channels",
+                              "One user"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":false,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     },
+                     {
+                        "planId":"essentials",
+                        "planName":"Essentials",
+                        "planInterval":"year",
+                        "channelsQuantity":1,
+                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
+                        "isCurrentPlan":false,
+                        "highlights":[
+                           "Advanced publishing tools",
+                           "Analytics & reporting",
+                           "Engagement tools"
+                        ],
+                        "currency":"$",
+                        "basePrice":5,
+                        "totalPrice":60,
+                        "discountPercentage":17,
+                        "discountNote":"17% Discount",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"Saving $12/year",
+                        "summary":{
+                           "details":[
+                              "Unlimited scheduled posts",
+                              "Unlimited social channels",
+                              "One user"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":false,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     },
+                     {
+                        "planId":"team",
+                        "planName":"Essentials + Team Pack",
+                        "planInterval":"year",
+                        "channelsQuantity":1,
+                        "description":"Collaborate with your team in one place & save time reporting.",
+                        "isCurrentPlan":false,
+                        "highlights":[
+                           "Advanced publishing tools",
+                           "Analytics & reporting",
+                           "Engagement tools",
+                           "Unlimited team members & clients",
+                           "Drafting & approval workflow tools",
+                           "Exportable PDF reports"
+                        ],
+                        "currency":"$",
+                        "basePrice":10,
+                        "totalPrice":120,
+                        "discountPercentage":17,
+                        "discountNote":"17% Discount",
+                        "priceNote":"Per social channel per month",
+                        "absoluteSavings":"Saving $24/year",
+                        "summary":{
+                           "details":[
+                              "Unlimited scheduled posts",
+                              "Unlimited social channels",
+                              "Unlimited users"
+                           ],
+                           "__typename":"OBPlanOptionSummary"
+                        },
+                        "isRecommended":true,
+                        "downgradedMessage":"",
+                        "channelSlotDetails":{
+                           "flatFee":0, 
+                           "currentQuantity":0, 
+                           "chargableQuantity":0, 
+                           "pricePerQuantity":0, 
+                           "minimumQuantity":0,
+                           "__typename": "ChannelSlotDetails"
+                        },
+                        "__typename":"OBPlanOption"
+                     }
+                  ],
+                  "__typename":"OBBilling"
+               },
+               "__typename":"AccountOrganization"
+            }
+         ],
+         "products":[
+            {
+               "name":"publish",
+               "userId":"606b65d760292104ad6ef6b5",
+               "__typename":"ProductLink"
+            },
+            {
+               "name":"analyze",
+               "userId":"606b65d6dad38c9d20b70792",
+               "__typename":"ProductLink"
+            },
+            {
+               "name":"engage",
+               "userId":"606b65d6dad38c9d20b70792",
+               "__typename":"ProductLink"
+            }
+         ],
+         "__typename":"Account"
+      }
+   }
+}

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -29,6 +29,36 @@ describe('Navigator', () => {
     });
   });
 
+  describe('OB Free Plan - upgrade flow', () => {
+    before(() => {
+      cy.fixture('accountObFreeUpgrade').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        }).as('getAccount');
+        cy.visit('/');
+        cy.wait('@getAccount').then(({ request }) => {
+          cy.task('log', `Request finished. Request data: ${request}`);
+        });
+      });
+    });
+
+    it('render the navigator', () => {
+      cy.get('#navigator').should('exist');
+      cy.get('#navigator > nav').should('exist');
+    });
+
+    it('has an upgrade CTA', () => {
+      cy.contains('Upgrade').should('exist');
+    });
+
+    it('a user can upgrade to essentials after clicking the upgrade button', () => {
+      cy.get('#upgradeCTA').click();
+      cy.get('#essentials_year').should('exist');
+      cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
+    });
+  });
+
   describe('OB Essentials Plan', () => {
     before(() => {
       cy.fixture('accountObEssential').then((account) => {

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -46,6 +46,7 @@ import {
   handleChannelsCountConditions,
   getCurrentPlanFromPlanOptions,
   calculateTotalSlotsPrice,
+  handleUpgradeIntent,
 } from '../../../utils';
 
 export const PlanSelectorContainer = ({
@@ -58,14 +59,7 @@ export const PlanSelectorContainer = ({
   isFreePlan,
   isUpgradeIntent,
 }) => {
-  const filterPlanOptions = () => {
-    if (isUpgradeIntent) {
-      return changePlanOptions.filter((option) => option.planId !== 'free');
-    }
-    return changePlanOptions;
-  };
-
-  const planOptions = filterPlanOptions();
+  const planOptions = changePlanOptions;
 
   const [error, setError] = useState(null);
   const [showAgencyPlan, setShowAgencyPlan] = useState(false);
@@ -74,36 +68,37 @@ export const PlanSelectorContainer = ({
   const { cta } = modalData || {};
   const { monthlyBilling, setBillingInterval } = useInterval(
     planOptions,
-    isUpgradeIntent
+    isUpgradeIntent,
+    showAgencyPlan
   );
   const { selectedPlan, updateSelectedPlan } = useSelectedPlan(
     planOptions,
     isUpgradeIntent,
-    user
+    showAgencyPlan
   );
 
-  // const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
+  const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
 
-  // const { currentQuantity } = currentPlan.channelSlotDetails;
-  // const {
-  //   flatFee: selectedPlanFlatFee,
-  //   pricePerQuantity: selectedPlanPricePerQuantity,
-  //   minimumQuantity: selectedPlanMinimumQuantity,
-  // } = selectedPlan.channelSlotDetails;
+  const { currentQuantity } = currentPlan.channelSlotDetails;
+  const {
+    flatFee: selectedPlanFlatFee,
+    pricePerQuantity: selectedPlanPricePerQuantity,
+    minimumQuantity: selectedPlanMinimumQuantity,
+  } = selectedPlan.channelSlotDetails;
 
   const {
     channelsCount,
     setChannelsCounterValue,
     increaseCounter,
     decreaseCounter,
-  } = useChannelsCounter(1, 1);
+  } = useChannelsCounter(currentQuantity, selectedPlanMinimumQuantity);
 
   const newPrice = calculateTotalSlotsPrice(
     selectedPlan.planId,
     channelsCount,
-    6,
-    1,
-    0
+    selectedPlanPricePerQuantity,
+    selectedPlanMinimumQuantity,
+    selectedPlanFlatFee
   );
 
   const {
@@ -134,7 +129,6 @@ export const PlanSelectorContainer = ({
   );
 
   const planOptionsWithoutFreePlans = filterListOfPlans(planOptions, 'free');
-
   const planOptionsWithoutAgencyPlans = filterListOfPlans(
     planOptions,
     'agency'
@@ -143,7 +137,7 @@ export const PlanSelectorContainer = ({
   const shouldIncludeAgencyPlan = isAgencyUser(user) || isOnAgencyTrial(user);
 
   const availablePlans =
-    shouldIncludeAgencyPlan || showAgencyPlan
+    shouldIncludeAgencyPlan || showAgencyPlan || isUpgradeIntent
       ? planOptionsWithoutFreePlans
       : planOptionsWithoutAgencyPlans;
 
@@ -178,6 +172,13 @@ export const PlanSelectorContainer = ({
   }, [monthlyBilling]);
 
   useEffect(() => {
+    handleUpgradeIntent(
+      selectedPlan.planId,
+      isUpgradeIntent,
+      monthlyBilling,
+      updateSelectedPlan
+    );
+
     handleChannelsCountConditions(
       selectedPlan.planId,
       channelsCount,
@@ -232,7 +233,7 @@ export const PlanSelectorContainer = ({
           updateSelectedPlan={updateSelectedPlan}
           monthlyBilling={monthlyBilling}
         />
-        {!shouldIncludeAgencyPlan && !showAgencyPlan && (
+        {!shouldIncludeAgencyPlan && !showAgencyPlan && !isUpgradeIntent && (
           <AgencyPlanSection
             ctaAction={() => {
               updateSelectedPlan(`agency_${monthlyBilling ? 'month' : 'year'}`);

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -68,13 +68,11 @@ export const PlanSelectorContainer = ({
   const { cta } = modalData || {};
   const { monthlyBilling, setBillingInterval } = useInterval(
     planOptions,
-    isUpgradeIntent,
-    showAgencyPlan
+    isUpgradeIntent
   );
   const { selectedPlan, updateSelectedPlan } = useSelectedPlan(
     planOptions,
-    isUpgradeIntent,
-    showAgencyPlan
+    isUpgradeIntent
   );
 
   const currentPlan = getCurrentPlanFromPlanOptions(planOptions);

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/SelectionScreen.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/SelectionScreen.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import Text from '@bufferapp/ui/Text';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
@@ -2,10 +2,9 @@ import { useState } from 'react';
 
 import { getDefaultSelectedPlan } from '../../../utils';
 
-const useInterval = (planOptions, isUpgradeIntent, user) => {
+const useInterval = (planOptions, isUpgradeIntent) => {
   const defaultSelectedPlan = getDefaultSelectedPlan(
     planOptions,
-    user, // TODO:REMOVE_WITH_FF:agencyPlan
     isUpgradeIntent
   );
 

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.test.jsx
@@ -1,10 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import useInterval from './useInterval';
 
-const user = {
-  featureFlips: ['featureFlips'],
-};
-
 describe('useInterval', () => {
   it("should set the current plan's interval as the initial interval", () => {
     const planOptions = [
@@ -14,9 +10,7 @@ describe('useInterval', () => {
     ];
     const isFreePlan = false;
 
-    const { result } = renderHook(() =>
-      useInterval(planOptions, isFreePlan, user)
-    );
+    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
 
     expect(result.current.monthlyBilling).toBe(true);
   });
@@ -29,9 +23,7 @@ describe('useInterval', () => {
 
     const isFreePlan = true;
 
-    const { result } = renderHook(() =>
-      useInterval(planOptions, isFreePlan, user)
-    );
+    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
 
     expect(result.current.monthlyBilling).toBeFalsy();
   });
@@ -43,9 +35,7 @@ describe('useInterval', () => {
     ];
     const isFreePlan = false;
 
-    const { result } = renderHook(() =>
-      useInterval(planOptions, isFreePlan, user)
-    );
+    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
     act(() => {
       result.current.setBillingInterval(!result.current.monthlyBilling);
     });

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.js
@@ -3,10 +3,9 @@ import { freePlan } from '../../../../../common/mocks/freePlan';
 
 import { getDefaultSelectedPlan } from '../../../utils';
 
-const useSelectedPlan = (planOptions, isUpgradeIntent, user) => {
+const useSelectedPlan = (planOptions, isUpgradeIntent) => {
   const defaultSelectedPlan = getDefaultSelectedPlan(
     planOptions,
-    user, // TODO:REMOVE_WITH_FF:agencyPlan
     isUpgradeIntent
   );
   const [selectedPlan, setSelectedPlan] = useState(defaultSelectedPlan);

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -54,27 +54,22 @@ export function userHasFeatureFlip(user, featureFlip) {
   return user.featureFlips.includes(featureFlip);
 }
 
-export function getDefaultSelectedPlan(planOptions, user, isUpgradeIntent) {
-  const featureFilpAgencyPlan = userHasFeatureFlip(user, 'agencyPlan'); // TODO:REMOVE_WITH_FF:agencyPlan
-
-  const currentPlan = planOptions.find((plan) => plan.isCurrentPlan);
-
-  const isOnFreePlan =
-    isUpgradeIntent || !currentPlan || currentPlan.planId === 'free'
-      ? true
-      : false;
-
-  const planOptionsExcludingFree = filterListOfPlans(planOptions, 'free');
-  const plans = featureFilpAgencyPlan ? planOptionsExcludingFree : planOptions;
-
-  const defaultSelectedPlan =
-    isOnFreePlan && !currentPlan ? plans[0] : currentPlan;
-
-  return defaultSelectedPlan;
+export function getPlanByPlanId(planId, planOptions) {
+  return planOptions.find((plan) => plan.planId === planId);
 }
 
 export function getCurrentPlanFromPlanOptions(planOptions) {
   return planOptions.find((plan) => plan.isCurrentPlan);
+}
+
+export function getDefaultSelectedPlan(planOptions, isUpgradeIntent) {
+  const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
+  const essentialsPlan = getPlanByPlanId('essentials', planOptions);
+
+  const defaultSelectedPlan =
+    isUpgradeIntent || !currentPlan ? essentialsPlan : currentPlan;
+
+  return defaultSelectedPlan;
 }
 
 export function calculateAgencySlotPrice(
@@ -121,5 +116,16 @@ export function handleChannelsCountConditions(
   }
   if (planId === 'free' && channelsCount > 3) {
     setChannelsCounterValue(3);
+  }
+}
+
+export function handleUpgradeIntent(
+  selectedPlanId,
+  isUpgradeIntent,
+  monthlyBilling,
+  updateSelectedPlan
+) {
+  if (selectedPlanId === 'free' && isUpgradeIntent) {
+    updateSelectedPlan(`essentials_${monthlyBilling ? 'month' : 'year'}`);
   }
 }

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -8,6 +8,7 @@ import {
   filterListOfPlans,
   getDefaultSelectedPlan,
   calculateTotalSlotsPrice,
+  getPlanByPlanId,
 } from './utils';
 
 const listOfPlanOptions = [
@@ -25,11 +26,6 @@ const listOfFilteredPlanOptions = [
   { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
   { planId: 'team', planInterval: 'year', isCurrentPlan: true },
 ];
-
-// TODO:REMOVE_WITH_FF:agencyPlan
-const user = {
-  featureFlips: ['agencyPlan'],
-};
 
 const isUpgradeIntent = false;
 
@@ -191,13 +187,13 @@ describe('Modal - utils', () => {
   });
 
   describe('getDefaultSelectedPlan', () => {
-    it('should set the default selected plan to the current plan when the current plan is not free', () => {
+    it('should set the default selected plan to the current plan when their is a currentPlan found', () => {
       const planOptions = [
         { planId: 'free', planInterval: 'month', isCurrentPlan: false },
         ...listOfFilteredPlanOptions,
       ];
 
-      const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
+      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
 
       expect(result).toEqual({
         planId: 'team',
@@ -206,40 +202,25 @@ describe('Modal - utils', () => {
       });
     });
 
-    it("should set the default selected plan to the first plan in list when it's a free plan AND there is no current plan available", () => {
+    it('should set the default selected plan to the current plan when isUpgradeIntent is true AND there is a current plan found', () => {
       const planOptions = [
         { planId: 'free', planInterval: 'month', isCurrentPlan: false },
-        ...listOfPlanOptionsWithNoCurrentPlan,
+        ...listOfFilteredPlanOptions,
       ];
 
-      const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
+      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
 
       expect(result).toEqual({
-        planId: 'essentials',
-        planInterval: 'month',
-        isCurrentPlan: false,
+        planId: 'team',
+        planInterval: 'year',
+        isCurrentPlan: true,
       });
     });
 
-    it('should set the default selected plan to the first plan in list when isUpgradeIntent is true AND there is no current plan available', () => {
-      const planOptions = [
-        { planId: 'free', planInterval: 'month', isCurrentPlan: false },
-        ...listOfPlanOptionsWithNoCurrentPlan,
-      ];
-
-      const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
-
-      expect(result).toEqual({
-        planId: 'essentials',
-        planInterval: 'month',
-        isCurrentPlan: false,
-      });
-    });
-
-    it('should set the default selected plan to the first plan in list when there is no plan in the list of options with isCurrentPlan set to true', () => {
+    it('should set the default selected plan to essentials when isCurrentPlan cannot be found in the list of plans', () => {
       const planOptions = [...listOfPlanOptionsWithNoCurrentPlan];
 
-      const result = getDefaultSelectedPlan(planOptions, user, isUpgradeIntent);
+      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
 
       expect(result).toEqual({
         planId: 'essentials',
@@ -248,15 +229,14 @@ describe('Modal - utils', () => {
       });
     });
 
-    it('should set the default selected plan to the current plan when isUpgradeIntent and there is a current plan available in list ', () => {
+    it('should set the default selected plan to essentials when isUpgradeIntent ', () => {
       const planOptions = [...listOfFilteredPlanOptions];
-
-      const result = getDefaultSelectedPlan(planOptions, user, true);
+      const result = getDefaultSelectedPlan(planOptions, true);
 
       expect(result).toEqual({
-        planId: 'team',
-        planInterval: 'year',
-        isCurrentPlan: true,
+        planId: 'essentials',
+        planInterval: 'month',
+        isCurrentPlan: false,
       });
     });
   });
@@ -381,6 +361,42 @@ describe('Modal - utils', () => {
         flatFee
       );
       expect(result).toEqual(132);
+    });
+  });
+
+  describe('getPlanByPlanId', () => {
+    it('should return essentials plan when provided with essentials id', () => {
+      const planId = 'essentials';
+
+      const result = getPlanByPlanId(planId, listOfPlanOptions);
+      expect(result).toEqual({
+        planId: 'essentials',
+        planInterval: 'month',
+        isCurrentPlan: false,
+      });
+    });
+
+    it('should return free plan when provided with free id', () => {
+      const planId = 'free';
+
+      const result = getPlanByPlanId(planId, listOfPlanOptions);
+      expect(result).toEqual({
+        planId: 'free',
+        planInterval: 'month',
+        isCurrentPlan: false,
+      });
+    });
+
+    it('should return the first essentials plan in list when provided with essentials id', () => {
+      const planId = 'essentials';
+      const plans = [
+        ...listOfPlanOptions,
+        { planId: 'essentials', planInterval: 'year', isCurrentPlan: false },
+        { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
+      ];
+
+      const result = getPlanByPlanId(planId, plans);
+      expect(result).toEqual(plans[1]);
     });
   });
 });


### PR DESCRIPTION
👀  Could someone do a quick check over this PR as it is to fix a bug which was found in production 😃 

This PR applies a fix to a recent incident that occurred on production. 

This affected users clicking on the Upgrade CTA in the Navigator and would cause the navigator to disappear and break completely.

This fix also contains a new Cypress test to catch this user flow in the future.

Slack thread with more conversation surrounding this: https://buffer.slack.com/archives/C0DLE125Q/p1645631159252259

Watch loom for more details:
https://www.loom.com/share/14a6cca013344049860b5f5367da3b80
