### PR TITLE
[GROW-347] remove split check for agency

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
@@ -2,16 +2,14 @@ import React from 'react';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
-import { useSplitEnabled } from '@bufferapp/features';
 
 import { Container } from './AgencyPlanSection.style';
 
 function AgencyPlanSection(props) {
   const { ctaAction } = props;
-  const { isEnabled: splitSBBEnabled } = useSplitEnabled('slot-based-billing');
 
   return (
-    <Container sbbEnabled={splitSBBEnabled}>
+    <Container>
       <Text htmlFor="agencyPlan" type="agency">
         Need more than 10 channels?{''}{' '}
         <Button

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.style.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.style.js
@@ -1,34 +1,13 @@
-import { grayLight, blue } from '@bufferapp/ui/style/colors';
+import { blue } from '@bufferapp/ui/style/colors';
 import styled from 'styled-components';
 
-const containerPaddingWidth = 15;
-const containerPaddingHeight = 8;
-
 export const Container = styled.div`
-  ${(props) => {
-    if (props.sbbEnabled) {
-      return `
-        display: flex;
-        width: 100%;
-        align-items: center;
-        width: 100%;
-        padding: 15px;
-      `;
-    }
-    return `
-      display: flex;
-      width: 100%;
-      height: 64px;
-      padding: ${containerPaddingHeight}px ${containerPaddingWidth}px;
-      margin-bottom: 22px;
-      align-items: center;
-      height: calc(64px - ${containerPaddingHeight}px);
-      width: calc(100% - ${containerPaddingWidth * 2}px);
-
-      border: 1px solid ${grayLight};
-      border-radius: 3px;
-    `;
-  }}
+  display: flex;
+  width: 100%;
+  align-items: center;
+  width: 100%;
+  padding: 15px;
+  margin-bottom: 22px;
 
   button {
     padding: 2px;

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
@@ -2,16 +2,14 @@ import React from 'react';
 
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
-import { useSplitEnabled } from '@bufferapp/features';
 
 import { Container } from './FreePlanSection.style';
 
 function FreePlanSection(props) {
   const { ctaAction } = props;
-  const { isEnabled: splitSBBEnabled } = useSplitEnabled('slot-based-billing');
 
   return (
-    <Container sbbEnabled={splitSBBEnabled}>
+    <Container>
       <Text htmlFor="foo" type="help">
         Looking for basic publishing tools?{''}{' '}
         <Button

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.style.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.style.js
@@ -1,33 +1,12 @@
 import { grayLight, blue } from '@bufferapp/ui/style/colors';
 import styled from 'styled-components';
-
-const containerPadding = 15;
-
 export const Container = styled.div`
-  ${(props) => {
-    if (props.sbbEnabled) {
-      return `
-        display: flex;
-        width: 100%;
-        align-items: center;
-        width: 100%;
-        padding: 15px;
-      `;
-    }
-    return `
-      display: flex;
-      width: 100%;
-      height: 64px;
-      padding: ${containerPadding}px;
-      margin-bottom: 16px;
-      align-items: center;
-      height: calc(64px - ${containerPadding}px);
-      width: calc(100% - ${containerPadding * 2}px);
-
-      border: 1px solid ${grayLight};
-      border-radius: 3px;
-    `;
-  }}
+  display: flex;
+  width: 100%;
+  align-items: center;
+  width: 100%;
+  padding: 15px;
+  margin-bottom: 16px;
 
   button {
     padding: 2px;

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.style.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.style.js
@@ -1,5 +1,6 @@
-import { grayLight, blue } from '@bufferapp/ui/style/colors';
+import { blue } from '@bufferapp/ui/style/colors';
 import styled from 'styled-components';
+
 export const Container = styled.div`
   display: flex;
   width: 100%;


### PR DESCRIPTION
Removing `slot-based-billing` split check for toggling between free and agency as we released agency to 100%.

Before
<img width="1245" alt="Screenshot 2022-02-24 at 08 52 13" src="https://user-images.githubusercontent.com/1514227/155481444-abdc573c-623b-4fb7-9558-3dabe927343e.png">

After
<img width="1247" alt="Screenshot 2022-02-24 at 08 44 35" src="https://user-images.githubusercontent.com/1514227/155481208-721454b7-5cbc-4455-8b41-fc92fafbd116.png">
<img width="1227" alt="Screenshot 2022-02-24 at 08 46 05" src="https://user-images.githubusercontent.com/1514227/155481218-bfa6b4c8-a951-4567-9060-014c8d64a451.png">

