### PR TITLE
[GROW-393] Add Bugsnag to app-shell

### DIFF
--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -64,6 +64,8 @@
     "@bufferapp/buffer-tracking-browser-ts": "^0.0.21",
     "@bufferapp/features": "^0.3.0",
     "@bufferapp/ui": "^5.75.7",
+    "@bugsnag/js": "^7.16.1",
+    "@bugsnag/plugin-react": "^7.16.1",
     "@stripe/react-stripe-js": "^1.3.0",
     "@stripe/stripe-js": "^1.13.0",
     "babel-loader": "8.1",

--- a/packages/app-shell/src/exports/Navigator/ErrorBoundary.jsx
+++ b/packages/app-shell/src/exports/Navigator/ErrorBoundary.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Bugsnag from '@bugsnag/js';
+import BugsnagPluginReact from '@bugsnag/plugin-react';
+
+Bugsnag.start({
+  apiKey: '34dc7834c1bea7ec57f9c365a12eb779',
+  plugins: [new BugsnagPluginReact()],
+  releaseStage: process.env.NODE_ENV,
+  enabledReleaseStages: ['production', 'staging'],
+});
+
+const ErrorBoundary = Bugsnag.getPlugin('react').createErrorBoundary(React);
+
+export default ErrorBoundary;

--- a/packages/app-shell/src/exports/Navigator/ErrorBoundary.jsx
+++ b/packages/app-shell/src/exports/Navigator/ErrorBoundary.jsx
@@ -3,7 +3,7 @@ import Bugsnag from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
 
 Bugsnag.start({
-  apiKey: '34dc7834c1bea7ec57f9c365a12eb779',
+  apiKey: '9edffce18cc87b968f0fcb654c020b65',
   plugins: [new BugsnagPluginReact()],
   releaseStage: process.env.NODE_ENV,
   enabledReleaseStages: ['production', 'staging'],

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -20,6 +20,7 @@ import useModal, { MODALS } from '../../common/hooks/useModal';
 import { QUERY_ACCOUNT } from '../../common/graphql/account';
 import useUserTracker from '../../common/hooks/useUserTracker';
 import getTrialBannerCopy from './getTrialBannerCopy';
+import ErrorBoundary from './ErrorBoundary';
 
 function getActiveProductFromUrl() {
   const productUrl = window.location.hostname.split('.')[0];
@@ -153,13 +154,15 @@ export default () => {
   });
 
   ReactDOM.render(
-    <React.StrictMode>
-      <ApolloProvider client={client}>
-        <FeaturesWrapper>
-          <Navigator />
-        </FeaturesWrapper>
-      </ApolloProvider>
-    </React.StrictMode>,
+    <ErrorBoundary>
+      <React.StrictMode>
+        <ApolloProvider client={client}>
+          <FeaturesWrapper>
+            <Navigator />
+          </FeaturesWrapper>
+        </ApolloProvider>
+      </React.StrictMode>
+    </ErrorBoundary>,
     document.getElementById('navigator')
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,59 @@
     react-is "^16.8.6"
     styled-components "^5.3.0"
 
+"@bugsnag/browser@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/browser/-/browser-7.16.1.tgz#652aa3ed64e51ba0015878d252a08917429bba03"
+  integrity sha512-Tq9fWpwmqdOsbedYL67GzsTKrG5MERIKtnKCi5FyvFjTj143b6as0pwj7LWQ+Eh8grWlR7S11+VvJmb8xnY8Tg==
+  dependencies:
+    "@bugsnag/core" "^7.16.1"
+
+"@bugsnag/core@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/core/-/core-7.16.1.tgz#0376b5c4dd7b44f57eb503775857d974e4b5afc9"
+  integrity sha512-zuBnL7B329VldItRqhXYrp1hjmjZnltJwNXMysi9WtY4t29WKk5LVwgWb1mPM9clJ0FoObZ7kvvQMUTKh3ezFQ==
+  dependencies:
+    "@bugsnag/cuid" "^3.0.0"
+    "@bugsnag/safe-json-stringify" "^6.0.0"
+    error-stack-parser "^2.0.3"
+    iserror "0.0.2"
+    stack-generator "^2.0.3"
+
+"@bugsnag/cuid@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/cuid/-/cuid-3.0.0.tgz#2ee7642a30aee6dc86f5e7f824653741e42e5c35"
+  integrity sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==
+
+"@bugsnag/js@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/js/-/js-7.16.1.tgz#4a4ec2c7f3e047333e7d15eb53cb11f165b7067f"
+  integrity sha512-yb83OmsbIMDJhX3hHhbHl5StN72feqdr/Ctq7gqsdcfOHNb2121Edf2EbegPJKZhFqSik66vWwiVbGJ6CdS/UQ==
+  dependencies:
+    "@bugsnag/browser" "^7.16.1"
+    "@bugsnag/node" "^7.16.1"
+
+"@bugsnag/node@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/node/-/node-7.16.1.tgz#473bb6eeb346b418295b49e4c4576e0004af4901"
+  integrity sha512-9zBA1IfDTbLKMoDltdhELpTd1e+b5+vUW4j40zGA+4SYIe64XNZKShfqRdvij7embvC1iHQ9UpuPRSk60P6Dng==
+  dependencies:
+    "@bugsnag/core" "^7.16.1"
+    byline "^5.0.0"
+    error-stack-parser "^2.0.2"
+    iserror "^0.0.2"
+    pump "^3.0.0"
+    stack-generator "^2.0.3"
+
+"@bugsnag/plugin-react@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@bugsnag/plugin-react/-/plugin-react-7.16.1.tgz#8abc7512c2a1d7f2422a20f103730bfd02cb5510"
+  integrity sha512-cMO1ujjo/cZTE3k6c/KpF7mFhWnYHjfn622NuvYijkNlRbxcdRXtLHhiPJ+gL31Z4AGA/PRvzWXxR4eWxHF8Mw==
+
+"@bugsnag/safe-json-stringify@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz#22abdcd83e008c369902976730c34c150148a758"
+  integrity sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -7971,6 +8024,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.2, error-stack-parser@^2.0.3:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.7.tgz#b0c6e2ce27d0495cf78ad98715e0cad1219abb57"
+  integrity sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==
+  dependencies:
+    stackframe "^1.1.1"
+
 error-stack-parser@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
@@ -10818,6 +10878,11 @@ isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+iserror@0.0.2, iserror@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+  integrity sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -16296,6 +16361,13 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-generator@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
 
 stack-utils@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
Created a new project in Bugsnag for [App Shell](https://app.bugsnag.com/buffer/app-shell/errors?filters[event.since]=30d&filters[error.status]=open&sort=last_seen)

This will enable Bugsnag only for `production` and `staging`.
This will also push errors to the Slack channel [#alerts-appshell](https://buffer.slack.com/archives/C034AEHFX9U/)

Tested locally, here's an [example of error](https://app.bugsnag.com/buffer/app-shell/errors/62176b77b1a02900082c4638?filters[event.since]=30d&filters[error.status]=open)

This is just a basic integration, there is more to do:
- Enable source maps so its easier to debug.
- Move API key to webpack environment var or somewhere else.

