### PR TITLE
do not hide the navigation when modals are open

### DIFF
--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SimpleModal from '@bufferapp/ui/SimpleModal';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { getCookie, setCookie, DATES } from '../../common/utils/cookies';
 import { MODALS } from '../../common/hooks/useModal';
@@ -20,6 +21,12 @@ import TrialExpired from './modals/TrialExpired';
 import QuantityUpdate from './modals/QuantityUpdate';
 
 import { shouldShowFreeUserStartTrialPrompt, shouldShowChannelConnectionPrompt } from './utils';
+
+const ModalWrapper = styled.div`
+  > div {
+    z-index: 1;
+  }
+`;
 
 function handleFreeUsersStartTrialPrompt(openModal) {
   openModal(MODALS.startTrial, {
@@ -164,7 +171,7 @@ const Modal = React.memo(({ modal, openModal }) => {
   return (
     <>
       {hasModal && (
-        <ModalContent modal={modal} closeAction={() => openModal(null)} />
+        <ModalWrapper><ModalContent modal={modal} closeAction={() => openModal(null)} /></ModalWrapper>
       )}
     </>
   );

--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -142,6 +142,7 @@ const NavBarStyled = styled.nav`
   height: 64px;
   justify-content: space-between;
   position: relative;
+  z-index: 2;
 `;
 
 const NavBarLeft = styled.div`


### PR DESCRIPTION
This prevents modals from hiding the navigation bar, following the design defined in [Figma](https://www.figma.com/file/ugvq6I5lJ07W1aJBJg4ihm/Onboarding-2022?node-id=1016%3A65416)

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/992920/155629640-6b2510be-f023-44fa-8872-9112f2bcdcd7.png">
