### PR TITLE
Set NODE_ENV for development

### DIFF
--- a/packages/app-shell/webpack.config.dev.js
+++ b/packages/app-shell/webpack.config.dev.js
@@ -26,6 +26,11 @@ const merged = merge(common, {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+      },
+    }),
   ],
 });
 


### PR DESCRIPTION
Sets `process.env.NODE_ENV` for development. 

We noticed that local development errors are alerting in Bugsnag ([Slack Thread](https://buffer.slack.com/archives/CPP95LDP1/p1646044554715609)). This sets  `development` as the environment when working locally to prevent these errors from reporting. 