### PR TITLE
Webapp 378 paywall modal

### DIFF
--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -75,6 +75,7 @@
     "prop-types": ">= 15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",
+    "react-player": "^2.9.0",
     "style-loader": "^2.0.0",
     "styled-components": "^5.3.0"
   },

--- a/packages/app-shell/src/common/hooks/useModal.js
+++ b/packages/app-shell/src/common/hooks/useModal.js
@@ -3,18 +3,19 @@ import { useState, useEffect, useCallback } from 'react';
 import eventDispatcher from './utils/eventDispatcher';
 
 export const MODALS = {
-  channelConnectionPrompt: 'channelConnectionPrompt',
   GEID1FreeTrialPrompt: 'GEID1FreeTrialPrompt',
+  channelConnectionPrompt: 'channelConnectionPrompt',
   essentialsPlan: 'essentialsPlan',
   essentialsPricing: 'essentialsPricing',
   paidMigration: 'paidMigration',
   paymentMethod: 'paymentMethod',
+  paywall: 'paywall',
   planSelector: 'planSelector',
+  quantityUpdate: 'quantityUpdate',
   startTrial: 'startTrial',
   success: 'success',
   trialExpired: 'trialExpired',
   upgradeSuccess: 'upgradeSuccess',
-  quantityUpdate: 'quantityUpdate'
 };
 
 export const EVENT_KEY = 'appshell__modal_event';

--- a/packages/app-shell/src/common/hooks/useSuggestedPlan.js
+++ b/packages/app-shell/src/common/hooks/useSuggestedPlan.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export function useSuggestedPlan(user) {
+  const [suggestedPlan, setSuggestedPlan] = useState(null);
+
+  useEffect(() => {
+    if (user) {
+      let plan = user.currentOrganization?.billing?.changePlanOptions.find(
+        (p) => p.isRecommended
+      );
+      if (!plan) {
+        plan = {
+          planId: 'team',
+          planInterval: 'month',
+        };
+      }
+      setSuggestedPlan(plan);
+    }
+  }, [user]);
+
+  return { suggestedPlan };
+};

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -19,8 +19,9 @@ import StickyModal from './modals/StickyModal';
 import Success from './modals/PaidMigration/Success';
 import TrialExpired from './modals/TrialExpired';
 import QuantityUpdate from './modals/QuantityUpdate';
+import { Paywall } from './modals/Paywall';
 
-import { shouldShowFreeUserStartTrialPrompt, shouldShowChannelConnectionPrompt } from './utils';
+import { shouldShowFreeUserStartTrialPrompt, shouldShowChannelConnectionPrompt, shouldShowPaywallModal } from './utils';
 
 const ModalWrapper = styled.div`
   > div {
@@ -108,6 +109,12 @@ const ModalContent = ({ modal, closeAction }) => {
           <QuantityUpdate modal={modal} />
         </SimpleModal>
       );
+    case MODALS.paywall:
+      return (
+        <SimpleModal closeAction={closeAction}>
+          <Paywall modal={modal} />
+        </SimpleModal>
+      );
     default:
       return null;
   }
@@ -161,6 +168,10 @@ const Modal = React.memo(({ modal, openModal }) => {
     // Show Channel Connection prompt
     if (shouldShowChannelConnectionPrompt(user)) {
       openModal(MODALS.channelConnectionPrompt);
+    }
+
+    if (shouldShowPaywallModal(user)) {
+      openModal(MODALS.paywall);
     }
   }, [user.loading]);
 

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
@@ -2,19 +2,11 @@ import React from 'react';
 import Text from '@bufferapp/ui/Text';
 import ReactPlayer from 'react-player';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
-import Button from '@bufferapp/ui/Button';
-import Link from '@bufferapp/ui/Link';
 
-import { useUser } from '../../../../../common/context/User';
 import * as styles from '../styles';
+import { Ctas } from './Ctas';
 
 export const AnalyticsContent = () => {
-  const user = useUser();
-  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
-  const { MODALS, actions } = window?.appshell || {};
-  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
-  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
-
   return (<styles.Content>
     <styles.Video>
       <ReactPlayer
@@ -42,6 +34,7 @@ export const AnalyticsContent = () => {
           <Text>Create gorgeous reports</Text>
         </li>
       </styles.List>
+      <Ctas />
     </styles.Info>
   </styles.Content>);
 };

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
@@ -16,7 +16,7 @@ export const AnalyticsContent = () => {
         light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-analytics.jpg"
         playIcon={<styles.PlayIcon />}
       />
-      <Text type="label" color="gray"> See how you can use Buffer’s tools together to grow your brand </Text>
+      <Text type="label"> See how you can use Buffer’s tools together to grow your brand </Text>
     </styles.Video>
     <styles.Info>
       <Text type="h2">Get in-depth insights to grow <br /> your brand on social media</Text>

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
@@ -16,7 +16,7 @@ export const AnalyticsContent = () => {
         light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-analytics.jpg"
         playIcon={<styles.PlayIcon />}
       />
-      <Text type="label"> See how you can use Buffer’s tools together to grow your brand </Text>
+      <Text> See how you can use Buffer’s tools together to grow your brand </Text>
     </styles.Video>
     <styles.Info>
       <Text type="h2">Get in-depth insights to grow <br /> your brand on social media</Text>

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/AnalyticsContent.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+import ReactPlayer from 'react-player';
+import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
+import Button from '@bufferapp/ui/Button';
+import Link from '@bufferapp/ui/Link';
+
+import { useUser } from '../../../../../common/context/User';
+import * as styles from '../styles';
+
+export const AnalyticsContent = () => {
+  const user = useUser();
+  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
+  const { MODALS, actions } = window?.appshell || {};
+  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
+  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
+
+  return (<styles.Content>
+    <styles.Video>
+      <ReactPlayer
+        url="https://www.youtube.com/watch?v=KHWHAeWQ1u8"
+        width="520px"
+        height="312px"
+        light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-analytics.jpg"
+        playIcon={<styles.PlayIcon />}
+      />
+      <Text type="label" color="gray"> See how you can use Buffer’s tools together to grow your brand </Text>
+    </styles.Video>
+    <styles.Info>
+      <Text type="h2">Get in-depth insights to grow <br /> your brand on social media</Text>
+      <styles.List>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>Get recommendations to grow your presence like “Best time to post”</Text>
+        </li>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>Measure social media performance</Text>
+        </li>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>Create gorgeous reports</Text>
+        </li>
+      </styles.List>
+    </styles.Info>
+  </styles.Content>);
+};
+

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import Button from '@bufferapp/ui/Button';
 import Link from '@bufferapp/ui/Link';
+import Text from '@bufferapp/ui/Text';
 
 import useStartTrial from '../../../../../common/hooks/useStartTrial';
 import { useSuggestedPlan } from '../../../../../common/hooks/useSuggestedPlan';
@@ -58,7 +59,7 @@ const Content = ({ openModal }) => {
         label={ctaLabel}
       />
       <Link newTab href={`https://buffer.com/${product}`}>Learn more</Link>
-      </styles.CTAs>
+      <Text>No credit card required</Text>
       <Error
         error={
           error
@@ -68,6 +69,7 @@ const Content = ({ openModal }) => {
             : null
         }
       />
+    </styles.CTAs>
     </>
   );
 };

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Button from '@bufferapp/ui/Button';
+import Link from '@bufferapp/ui/Link';
+
+import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
+import { useUser } from '../../../../../common/context/User';
+import * as styles from '../styles';
+
+export const Ctas = () => {
+  const user = useUser();
+  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
+  const { MODALS, actions } = window?.appshell || {};
+  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
+  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
+  const product = getActiveProductFromPath();
+
+  return (<styles.CTAs>
+    <Button
+      type="primary"
+      onClick={() => {
+        actions.openModal(modal, {
+          cta,
+          ctaButton: `paywall-${cta}-1`,
+          isUpgradeIntent: true,
+        });
+      }}
+      label={canStartTrial ? 'Start free Trial' : 'Upgrade Plan'}
+    />
+    <Link newTab href={`https://buffer.com/${product}`}>Learn more</Link>
+  </styles.CTAs>);
+};
+

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
@@ -1,32 +1,82 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Button from '@bufferapp/ui/Button';
 import Link from '@bufferapp/ui/Link';
 
+import useStartTrial from '../../../../../common/hooks/useStartTrial';
+import { useSuggestedPlan } from '../../../../../common/hooks/useSuggestedPlan';
 import { getActiveProductFromPath } from '../../../../../common/utils/getProduct';
 import { useUser } from '../../../../../common/context/User';
+import { MODALS } from '../../../../../common/hooks/useModal';
+import { ModalContext } from '../../../../../common/context/Modal';
+import { Error } from '../../PaymentMethod/style';
 import * as styles from '../styles';
 
-export const Ctas = () => {
+const Content = ({ openModal }) => {
   const user = useUser();
-  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
-  const { MODALS, actions } = window?.appshell || {};
-  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
-  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
   const product = getActiveProductFromPath();
 
-  return (<styles.CTAs>
-    <Button
-      type="primary"
-      onClick={() => {
-        actions.openModal(modal, {
-          cta,
-          ctaButton: `paywall-${cta}-1`,
-          isUpgradeIntent: true,
-        });
-      }}
-      label={canStartTrial ? 'Start free Trial' : 'Upgrade Plan'}
-    />
-    <Link newTab href={`https://buffer.com/${product}`}>Learn more</Link>
-  </styles.CTAs>);
+  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
+  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
+
+  const { suggestedPlan } = useSuggestedPlan(user);
+  const { startTrial, trial, error, processing } = useStartTrial({
+    user,
+    plan: suggestedPlan,
+    attribution: { cta },
+  });
+
+  let ctaLabel = canStartTrial ? 'Start a 14-day free trial' : 'Upgrade Plan';
+  if (processing) {
+    ctaLabel = 'Processing ...';
+  }
+
+  useEffect(() => {
+    if (trial && trial.billingStartTrial.success) {
+      openModal(MODALS.success, {
+        startedTrial: true,
+        selectedPlan: suggestedPlan,
+      });
+    }
+  }, [trial]);
+
+  return (<>
+    <styles.CTAs>
+      <Button
+        type="primary"
+        disabled={processing}
+        onClick={() => {
+          if (canStartTrial) {
+            startTrial()
+          } else {
+            openModal(MODALS.planSelector, {
+              cta,
+              ctaButton: `paywall-${cta}-1`,
+              isUpgradeIntent: true,
+            });
+          }
+        }}
+        label={ctaLabel}
+      />
+      <Link newTab href={`https://buffer.com/${product}`}>Learn more</Link>
+      </styles.CTAs>
+      <Error
+        error={
+          error
+            ? {
+                message: error.message,
+              }
+            : null
+        }
+      />
+    </>
+  );
+};
+
+export const Ctas = () => {
+  return (<ModalContext.Consumer>
+    {({ openModal }) => (
+      <Content openModal={openModal} />
+    )}
+  </ModalContext.Consumer>);
 };
 

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
@@ -16,7 +16,7 @@ export const EngagementContent = () => {
         light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-engagement.jpg"
         playIcon={<styles.PlayIcon />}
       />
-      <Text type="label"> See how you can use Buffer’s tools together to grow your brand </Text>
+      <Text> See how you can use Buffer’s tools together to grow your brand </Text>
     </styles.Video>
     <styles.Info>
       <Text type="h2">Turn your followers into your <br/> fans</Text>

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Text from '@bufferapp/ui/Text';
+import ReactPlayer from 'react-player';
+import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
+import Button from '@bufferapp/ui/Button';
+import Link from '@bufferapp/ui/Link';
+
+import { useUser } from '../../../../../common/context/User';
+import * as styles from '../styles';
+
+export const EngagementContent = () => {
+  const user = useUser();
+  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
+  const { MODALS, actions } = window?.appshell || {};
+  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
+  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
+
+  return (<styles.Content>
+    <styles.Video>
+      <ReactPlayer
+        url="https://www.youtube.com/watch?v=KHWHAeWQ1u8"
+        width="520px"
+        height="312px"
+        light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-engagement.jpg"
+        playIcon={<styles.PlayIcon />}
+      />
+      <Text type="label" color="gray"> See how you can use Buffer’s tools together to grow your brand </Text>
+    </styles.Video>
+    <styles.Info>
+      <Text type="h2">Turn your followers into your <br/> fans</Text>
+      <styles.List>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>View unanswered comments in a simple dashboard</Text>
+        </li>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>Machine-learning-powered comment alerts</Text>
+        </li>
+        <li>
+          <styles.Check><CheckmarkIcon /></styles.Check>
+          <Text>Reply faster with hotkeys and a smart emoji picker</Text>
+        </li>
+      </styles.List>
+      <styles.CTAs>
+        <Button
+          type="primary"
+          onClick={() => {
+            actions.openModal(modal, {
+              cta,
+              ctaButton: `paywall-${cta}-1`,
+              isUpgradeIntent: true,
+            });
+          }}
+          label={canStartTrial ? 'Start free Trial' : 'Upgrade Plan'}
+        />
+        <Link newTab href="https://buffer.com/engage ">Learn more</Link>
+      </styles.CTAs>
+    </styles.Info>
+  </styles.Content>);
+};
+

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
@@ -16,7 +16,7 @@ export const EngagementContent = () => {
         light="https://buffer-ui.s3.amazonaws.com/video-thumbnail-engagement.jpg"
         playIcon={<styles.PlayIcon />}
       />
-      <Text type="label" color="gray"> See how you can use Buffer’s tools together to grow your brand </Text>
+      <Text type="label"> See how you can use Buffer’s tools together to grow your brand </Text>
     </styles.Video>
     <styles.Info>
       <Text type="h2">Turn your followers into your <br/> fans</Text>

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/EngagementContent.jsx
@@ -2,19 +2,11 @@ import React from 'react';
 import Text from '@bufferapp/ui/Text';
 import ReactPlayer from 'react-player';
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
-import Button from '@bufferapp/ui/Button';
-import Link from '@bufferapp/ui/Link';
 
-import { useUser } from '../../../../../common/context/User';
 import * as styles from '../styles';
+import { Ctas } from './Ctas';
 
 export const EngagementContent = () => {
-  const user = useUser();
-  const canStartTrial = user?.currentOrganization?.billing?.canStartTrial;
-  const { MODALS, actions } = window?.appshell || {};
-  const modal = canStartTrial ? MODALS?.startTrial : MODALS?.planSelector;
-  const cta = canStartTrial ? 'startTrial' : 'upgradePlan';
-
   return (<styles.Content>
     <styles.Video>
       <ReactPlayer
@@ -42,21 +34,7 @@ export const EngagementContent = () => {
           <Text>Reply faster with hotkeys and a smart emoji picker</Text>
         </li>
       </styles.List>
-      <styles.CTAs>
-        <Button
-          type="primary"
-          onClick={() => {
-            actions.openModal(modal, {
-              cta,
-              ctaButton: `paywall-${cta}-1`,
-              isUpgradeIntent: true,
-            });
-          }}
-          label={canStartTrial ? 'Start free Trial' : 'Upgrade Plan'}
-        />
-        <Link newTab href="https://buffer.com/engage ">Learn more</Link>
-      </styles.CTAs>
+      <Ctas />
     </styles.Info>
   </styles.Content>);
 };
-

--- a/packages/app-shell/src/components/Modal/modals/Paywall/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/index.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { BufferTracker } from '@bufferapp/buffer-tracking-browser-ts';
+import { useUser } from '../../../../common/context/User';
+import { getActiveProductFromPath } from '../../../../common/utils/getProduct';
+import { EngagementContent } from './components/EngagementContent';
+import { AnalyticsContent } from './components/AnalyticsContent';
+
+export const Paywall = () => {
+  const user = useUser();
+  const product = getActiveProductFromPath();
+
+  useEffect(() => {
+    BufferTracker.pageViewed({
+      name: 'paywall modal',
+      product: window.PRODUCT_TRACKING_KEY,
+      organizationId: user?.currentOrganization?.organizationId,
+    });
+  }, [user]);
+
+  return (<>
+    {product === 'engage' && (<EngagementContent />)}
+    {product === 'analyze' && (<AnalyticsContent />)}
+  </>);
+};

--- a/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
@@ -99,6 +99,7 @@ export const CTAs = styled.div`
   display: flex;
   align-items: center;
   width :339px;
+  margin-bottom: 8px;
 
   a {
     margin-left: 32px;

--- a/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+import { grayLighter, blue, white } from '@bufferapp/ui/style/colors';
+
+export const Content = styled.div`
+  width: 1153px;
+  height: 539px;
+  background: ${grayLighter};
+  padding: 64px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Video = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 520px;
+
+  label {
+    margin-top: 16px;
+  }
+`;
+
+export const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  margin-left: 64px;
+  width :371px;
+`;
+
+export const PlayIcon = styled.div`
+  width: 75px;
+  height: 75px;
+  border-radius: 75px;
+  background-color: rgba(184,184,184,.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 180ms ease-in;
+
+  &:after {
+    content: '';
+    display: block;
+    box-sizing: border-box;
+    transition: all 100ms ease-in;
+    border-left: solid ${blue} 28px;
+    border-top: solid transparent calc(31px / 2);
+    border-bottom: solid transparent calc(31px / 2);
+    margin-left: 8px;
+  }
+
+  &:hover {
+    width: 82px;
+    height: 82px;
+    background-color: rgba(184,184,184,.6);
+    &:after {
+      transform: scale(1.2);
+    }
+  }
+`;
+
+export const List = styled.ul`
+  padding: 0;
+  list-style: none;
+    align-items: center;
+
+  li {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    margin-bottom: 14px;
+
+    span {
+      font-size: 14px;
+    }
+  }
+`;
+
+export const Check = styled.span`
+  width: 24px;
+  height: 24px;
+  border-radius: 24px;
+  background-color: ${blue};
+  margin-right: 8px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+
+  svg {
+    color: ${white}
+  }
+`;
+
+export const CTAs = styled.div`
+  display: flex;
+  align-items: center;
+  width :339px;
+
+  a {
+    margin-left: 32px;
+    font-weight: 700;
+  }
+`;

--- a/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/styles.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { grayLighter, blue, white } from '@bufferapp/ui/style/colors';
+import { grayLighter, gray, blue, white } from '@bufferapp/ui/style/colors';
 
 export const Content = styled.div`
   width: 1153px;
@@ -18,8 +18,9 @@ export const Video = styled.div`
   align-items: center;
   width: 520px;
 
-  label {
+  span {
     margin-top: 16px;
+    font-size: 14px;
   }
 `;
 
@@ -97,6 +98,7 @@ export const Check = styled.span`
 
 export const CTAs = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   width :339px;
   margin-bottom: 8px;
@@ -104,5 +106,15 @@ export const CTAs = styled.div`
   a {
     margin-left: 32px;
     font-weight: 700;
+  }
+
+  span {
+    margin-top: 8px;
+    font-size: 14px;
+    color: ${gray};
+  }
+
+  > * {
+    flex-shrink: 0;
   }
 `;

--- a/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/StartTrial/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import CheckmarkIcon from '@bufferapp/ui/Icon/Icons/Checkmark';
 import Text from '@bufferapp/ui/Text';
@@ -9,28 +9,14 @@ import { MODALS } from '../../../../common/hooks/useModal';
 import { UserContext } from '../../../../common/context/User';
 import { ModalContext } from '../../../../common/context/Modal';
 import useStartTrial from '../../../../common/hooks/useStartTrial';
+import { useSuggestedPlan } from '../../../../common/hooks/useSuggestedPlan';
 import { useTrackPageViewed } from '../../../../common/hooks/useSegmentTracking';
 
 import { Holder, Content, Ctas } from './style';
 
 const StartTrial = ({ user, openModal, modalData }) => {
-  const [suggestedPlan, setSuggestedPlan] = useState(null);
+  const { suggestedPlan } = useSuggestedPlan(user);
   const { cta, ctaButton } = modalData || {};
-
-  useEffect(() => {
-    if (user) {
-      let plan = user.currentOrganization?.billing?.changePlanOptions.find(
-        (p) => p.isRecommended
-      );
-      if (!plan) {
-        plan = {
-          planId: 'team',
-          planInterval: 'month',
-        };
-      }
-      setSuggestedPlan(plan);
-    }
-  }, [user]);
 
   const { startTrial, trial, error, processing } = useStartTrial({
     user,

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -40,6 +40,14 @@ export function shouldShowFreeUserStartTrialPrompt(user) {
   );
 }
 
+export function shouldShowPaywallModal(user) {
+  const activeProduct = getActiveProductFromPath();
+  return (
+    (activeProduct === 'analyze' || activeProduct === 'engage') &&
+    isFreeUser(user)
+  );
+}
+
 export function filterListOfPlans(planOptions, planToExclude) {
   const planOptionsFiltered = planOptions.filter(
     (plan) => plan.planId !== planToExclude

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -5,6 +5,7 @@ import {
   isPendoModalVisible,
   hasSeenFreeUserStartTrialPrompt,
   shouldShowFreeUserStartTrialPrompt,
+  shouldShowPaywallModal,
   shouldShowChannelConnectionPrompt,
   filterListOfPlans,
   getDefaultSelectedPlan,
@@ -449,6 +450,68 @@ describe('Modal - utils', () => {
 
       const result = getPlanByPlanId(planId, plans);
       expect(result).toEqual(plans[1]);
+    });
+  });
+
+  describe('shouldShowPaywallModal', () => {
+    beforeEach(() => {
+      global.window = Object.create(window);
+      const url = 'http://analyze.bufer.com';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: {
+          origin: url,
+        },
+      });
+    });
+
+    it('should return false if not a free user', () => {
+      const mockUserData = MOCK_ACCOUNT_OB_ESSENTIAL_DATA.data.account;
+      const result = shouldShowPaywallModal(mockUserData);
+      expect(result).toBeFalsy();
+    });
+
+    it('should return true if free user on Analytics', () => {
+      const mockUserData = MOCK_ACCOUNT_OB_FREE_DATA.data.account;
+      const result = shouldShowPaywallModal(mockUserData);
+      expect(result).toBeTruthy();
+    });
+
+    it('should return true if free user on Engagement', () => {
+      global.window = Object.create(window);
+      const url = 'http://engage.bufer.com';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: {
+          origin: url,
+        },
+      });
+      const mockUserData = MOCK_ACCOUNT_OB_FREE_DATA.data.account;
+      const result = shouldShowPaywallModal(mockUserData);
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false if product not analyze or engage', () => {
+      global.window = Object.create(window);
+      const url = 'http://publish.bufer.com';
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: {
+          origin: url,
+        },
+      });
+      const mockUserData = MOCK_ACCOUNT_OB_FREE_DATA.data.account;
+      const noChannelsUser = Object.assign(mockUserData, {
+        currentOrganization: {
+          ...mockUserData.currentOrganization,
+          channels: [],
+        },
+      });
+      const result = shouldShowPaywallModal(noChannelsUser);
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -60,6 +60,17 @@ const ModalTesting = () => {
       >
         Render Modal
       </button>
+      <h3>Render Paywall modal</h3>
+      <button
+        onClick={() => {
+          const { MODALS, actions } = window?.appshell || {};
+          actions.openModal(MODALS.paywall, {
+            cta: 'paywall',
+          });
+        }}
+      >
+        Render Modal
+      </button>
     </Wrapper>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7466,7 +7466,7 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
-deepmerge@^4.2.2:
+deepmerge@^4.0.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -11766,6 +11766,11 @@ load-json-file@^5.3.0:
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -14948,6 +14953,17 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-player@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.9.0.tgz#ef7fe7073434087565f00ff219824e1e02c4b046"
+  integrity sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 react-popper-tooltip@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This adds the Analytics and Engagement Paywall modals for Free users

### Context & Notes
[WEBAPP-308](https://buffer.atlassian.net/browse/WEBAPP-308)

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/992920/156096148-88eb862b-1c6c-4c60-9c52-2095fc84091d.png">

_Note: it replaces the modals added in https://github.com/bufferapp/buffer-analyze/pull/1151, and https://github.com/bufferapp/buffer-engage-client/pull/286 so that we can directly trigger the upgrade action._