### PR TITLE
[COREP-610] Display email verification required banner

### DIFF
--- a/cypress/fixtures/accountObEssential.json
+++ b/cypress/fixtures/accountObEssential.json
@@ -1,620 +1,609 @@
 {
-   "data":{
-      "account":{
-         "id":"606b65d6dad38c9d20b70792",
-         "email":"ob_essential@buffer.com",
-         "createdAt":"2021-04-05T19:32:38.841Z",
-         "featureFlips":[
+  "data": {
+    "account": {
+      "id": "606b65d6dad38c9d20b70792",
+      "email": "ob_essential@buffer.com",
+      "createdAt": "2021-04-05T19:32:38.841Z",
+      "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
+      "isImpersonation": false,
+      "shouldShowEmailVerificationCommunication": true,
+      "currentOrganization": {
+        "id": "606b65d6dad38c03d2b70793",
+        "name": "test",
+        "canEdit": true,
+        "role": "admin",
+        "canMigrateToOneBuffer": {
+          "canMigrate": false,
+          "reasons": [
+            "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+          ],
+          "__typename": "CanMigrateToOneBuffer"
+        },
+        "createdAt": "2021-04-05T19:32:38.961Z",
+        "isOneBufferOrganization": true,
+        "shouldDisplayInviteCTA": false,
+        "featureFlips": [
+          "grantAnalyzeAccess",
+          "sharedChannels",
+          "engageRollOut"
+        ],
+        "channels": [
+          {
+            "id": "606b65e1dd934f70840bfef7",
+            "__typename": "Channel"
+          }
+        ],
+        "billing": {
+          "id": "606b65d6dad38c03d2b70793",
+          "canAccessAnalytics": true,
+          "canAccessEngagement": true,
+          "canAccessPublishing": true,
+          "paymentDetails": {
+            "hasPaymentDetails": true,
+            "__typename": "PaymentDetails"
+          },
+          "canStartTrial": false,
+          "subscription": {
+            "quantity": 1,
+            "interval": "year",
+            "periodEnd": "2022-08-04T21:25:40.000Z",
+            "isCanceledAtPeriodEnd": false,
+            "trial": null,
+            "plan": {
+              "id": "essentials",
+              "name": "Essentials",
+              "__typename": "OBPlan"
+            },
+            "__typename": "OBSubscription"
+          },
+          "changePlanOptions": [
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": false,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 6,
+              "totalPrice": 6,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 12,
+              "totalPrice": 12,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": false,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "0% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": true,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 5,
+              "totalPrice": 60,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 10,
+              "totalPrice": 120,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            }
+          ],
+          "__typename": "OBBilling"
+        },
+        "__typename": "AccountOrganization"
+      },
+      "organizations": [
+        {
+          "id": "606b65d6dad38c03d2b70793",
+          "name": "test",
+          "canEdit": true,
+          "role": "admin",
+          "canMigrateToOneBuffer": {
+            "canMigrate": false,
+            "reasons": [
+              "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+            ],
+            "__typename": "CanMigrateToOneBuffer"
+          },
+          "createdAt": "2021-04-05T19:32:38.961Z",
+          "isOneBufferOrganization": true,
+          "shouldDisplayInviteCTA": false,
+          "featureFlips": [
             "grantAnalyzeAccess",
             "sharedChannels",
             "engageRollOut"
-         ],
-         "isImpersonation":false,
-         "currentOrganization":{
-            "id":"606b65d6dad38c03d2b70793",
-            "name":"test",
-            "canEdit":true,
-            "role":"admin",
-            "canMigrateToOneBuffer": {
-               "canMigrate": false,
-               "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-               "__typename": "CanMigrateToOneBuffer"
+          ],
+          "channels": [
+            {
+              "id": "606b65e1dd934f70840bfef7",
+              "name": "testing public",
+              "service": "facebook",
+              "organizationId": "606b65d6dad38c03d2b70793",
+              "__typename": "Channel"
+            }
+          ],
+          "billing": {
+            "id": "606b65d6dad38c03d2b70793",
+            "canAccessAnalytics": true,
+            "canAccessEngagement": true,
+            "canAccessPublishing": true,
+            "paymentDetails": {
+              "hasPaymentDetails": true,
+              "__typename": "PaymentDetails"
             },
-            "createdAt":"2021-04-05T19:32:38.961Z",
-            "isOneBufferOrganization":true,
-            "shouldDisplayInviteCTA":false,
-            "featureFlips":[
-               "grantAnalyzeAccess",
-               "sharedChannels",
-               "engageRollOut"
-            ],
-            "channels":[
+            "canStartTrial": false,
+            "subscription": {
+              "quantity": 1,
+              "interval": "year",
+              "periodEnd": "2022-08-04T21:25:40.000Z",
+              "isCanceledAtPeriodEnd": false,
+              "trial": null,
+              "plan": {
+                "id": "essentials",
+                "name": "Essentials",
+                "__typename": "OBPlan"
+              },
+              "__typename": "OBSubscription"
+            },
+            "changePlanOptions": [
               {
-                "id":"606b65e1dd934f70840bfef7",
-                "__typename":"Channel"
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 6,
+                "totalPrice": 6,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 12,
+                "totalPrice": 12,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "0% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": true,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 5,
+                "totalPrice": 60,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
               }
             ],
-            "billing":{
-               "id":"606b65d6dad38c03d2b70793",
-               "canAccessAnalytics":true,
-               "canAccessEngagement":true,
-               "canAccessPublishing":true,
-               "paymentDetails":{
-                  "hasPaymentDetails":true,
-                  "__typename":"PaymentDetails"
-               },
-               "canStartTrial":false,
-               "subscription":{
-                  "quantity": 1,
-                  "interval":"year",
-                  "periodEnd":"2022-08-04T21:25:40.000Z",
-                  "isCanceledAtPeriodEnd":false,
-                  "trial":null,
-                  "plan":{
-                     "id":"essentials",
-                     "name":"Essentials",
-                     "__typename":"OBPlan"
-                  },
-                  "__typename":"OBSubscription"
-               },
-               "changePlanOptions":[
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":6,
-                     "totalPrice":6,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":12,
-                     "totalPrice":12,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"0% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":5,
-                     "totalPrice":60,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":10,
-                     "totalPrice":120,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  }
-               ],
-               "__typename":"OBBilling"
-            },
-            "__typename":"AccountOrganization"
-         },
-         "organizations":[
-            {
-               "id":"606b65d6dad38c03d2b70793",
-               "name":"test",
-               "canEdit":true,
-               "role":"admin",
-               "canMigrateToOneBuffer": {
-                  "canMigrate": false,
-                  "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-                  "__typename": "CanMigrateToOneBuffer"
-               },
-               "createdAt":"2021-04-05T19:32:38.961Z",
-               "isOneBufferOrganization":true,
-               "shouldDisplayInviteCTA":false,
-               "featureFlips":[
-                  "grantAnalyzeAccess",
-                  "sharedChannels",
-                  "engageRollOut"
-               ],
-               "channels":[
-                  {
-                     "id":"606b65e1dd934f70840bfef7",
-                     "name":"testing public",
-                     "service":"facebook",
-                     "organizationId":"606b65d6dad38c03d2b70793",
-                     "__typename":"Channel"
-                  }
-               ],
-               "billing":{
-                  "id":"606b65d6dad38c03d2b70793",
-                  "canAccessAnalytics":true,
-                  "canAccessEngagement":true,
-                  "canAccessPublishing":true,
-                  "paymentDetails":{
-                     "hasPaymentDetails":true,
-                     "__typename":"PaymentDetails"
-                  },
-                  "canStartTrial":false,
-                  "subscription":{
-                     "quantity": 1,
-                     "interval":"year",
-                     "periodEnd":"2022-08-04T21:25:40.000Z",
-                     "isCanceledAtPeriodEnd":false,
-                     "trial":null,
-                     "plan":{
-                        "id":"essentials",
-                        "name":"Essentials",
-                        "__typename":"OBPlan"
-                     },
-                     "__typename":"OBSubscription"
-                  },
-                  "changePlanOptions":[
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":6,
-                        "totalPrice":6,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":12,
-                        "totalPrice":12,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"0% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":5,
-                        "totalPrice":60,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":10,
-                        "totalPrice":120,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     }
-                  ],
-                  "__typename":"OBBilling"
-               },
-               "__typename":"AccountOrganization"
-            }
-         ],
-         "products":[
-            {
-               "name":"publish",
-               "userId":"606b65d760292104ad6ef6b5",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"analyze",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"engage",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            }
-         ],
-         "__typename":"Account"
-      }
-   }
+            "__typename": "OBBilling"
+          },
+          "__typename": "AccountOrganization"
+        }
+      ],
+      "products": [
+        {
+          "name": "publish",
+          "userId": "606b65d760292104ad6ef6b5",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "analyze",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "engage",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        }
+      ],
+      "__typename": "Account"
+    }
+  }
 }

--- a/cypress/fixtures/accountObEssentialNoChannels.json
+++ b/cypress/fixtures/accountObEssentialNoChannels.json
@@ -1,611 +1,602 @@
 {
-   "data":{
-      "account":{
-         "id":"606b65d6dad38c9d20b70792",
-         "email":"ob_free@buffer.com",
-         "createdAt":"2021-04-05T19:32:38.841Z",
-         "featureFlips":[
+  "data": {
+    "account": {
+      "id": "606b65d6dad38c9d20b70792",
+      "email": "ob_free@buffer.com",
+      "createdAt": "2021-04-05T19:32:38.841Z",
+      "featureFlips": [
+        "grantAnalyzeAccess",
+        "sharedChannels",
+        "engageRollOut",
+        "geid1_free_user_trial_prompt"
+      ],
+      "isImpersonation": false,
+      "shouldShowEmailVerificationCommunication": true,
+      "currentOrganization": {
+        "id": "606b65d6dad38c03d2b70793",
+        "name": "test",
+        "canEdit": true,
+        "role": "admin",
+        "canMigrateToOneBuffer": {
+          "canMigrate": false,
+          "reasons": [
+            "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+          ],
+          "__typename": "CanMigrateToOneBuffer"
+        },
+        "createdAt": "2021-04-05T19:32:38.961Z",
+        "isOneBufferOrganization": true,
+        "shouldDisplayInviteCTA": false,
+        "featureFlips": [
+          "grantAnalyzeAccess",
+          "sharedChannels",
+          "engageRollOut",
+          "geid1_free_user_trial_prompt"
+        ],
+        "channels": [],
+        "billing": {
+          "id": "606b65d6dad38c03d2b70793",
+          "canAccessAnalytics": false,
+          "canAccessEngagement": false,
+          "canAccessPublishing": true,
+          "paymentDetails": {
+            "hasPaymentDetails": true,
+            "__typename": "PaymentDetails"
+          },
+          "canStartTrial": true,
+          "subscription": {
+            "quantity": 1,
+            "interval": "month",
+            "periodEnd": null,
+            "isCanceledAtPeriodEnd": false,
+            "trial": null,
+            "plan": {
+              "id": "essentials",
+              "name": "Essentials",
+              "__typename": "OBPlan"
+            },
+            "__typename": "OBSubscription"
+          },
+          "changePlanOptions": [
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": true,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 6,
+              "totalPrice": 6,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 12,
+              "totalPrice": 12,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": true,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": true,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "0% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 5,
+              "totalPrice": 60,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 10,
+              "totalPrice": 120,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": true,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            }
+          ],
+          "__typename": "OBBilling"
+        },
+        "__typename": "AccountOrganization"
+      },
+      "organizations": [
+        {
+          "id": "606b65d6dad38c03d2b70793",
+          "name": "test",
+          "canEdit": true,
+          "role": "admin",
+          "canMigrateToOneBuffer": {
+            "canMigrate": false,
+            "reasons": [
+              "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+            ],
+            "__typename": "CanMigrateToOneBuffer"
+          },
+          "createdAt": "2021-04-05T19:32:38.961Z",
+          "isOneBufferOrganization": true,
+          "shouldDisplayInviteCTA": false,
+          "featureFlips": [
             "grantAnalyzeAccess",
             "sharedChannels",
-            "engageRollOut",
-            "geid1_free_user_trial_prompt"
-         ],
-         "isImpersonation":false,
-         "currentOrganization":{
-            "id":"606b65d6dad38c03d2b70793",
-            "name":"test",
-            "canEdit":true,
-            "role":"admin",
-            "canMigrateToOneBuffer": {
-               "canMigrate": false,
-               "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-               "__typename": "CanMigrateToOneBuffer"
+            "engageRollOut"
+          ],
+          "channels": [],
+          "billing": {
+            "id": "606b65d6dad38c03d2b70793",
+            "canAccessAnalytics": false,
+            "canAccessEngagement": false,
+            "canAccessPublishing": true,
+            "paymentDetails": {
+              "hasPaymentDetails": true,
+              "__typename": "PaymentDetails"
             },
-            "createdAt":"2021-04-05T19:32:38.961Z",
-            "isOneBufferOrganization":true,
-            "shouldDisplayInviteCTA":false,
-            "featureFlips":[
-               "grantAnalyzeAccess",
-               "sharedChannels",
-               "engageRollOut",
-               "geid1_free_user_trial_prompt"
-            ],
-            "channels":[
-            ],
-            "billing":{
-               "id":"606b65d6dad38c03d2b70793",
-               "canAccessAnalytics":false,
-               "canAccessEngagement":false,
-               "canAccessPublishing":true,
-               "paymentDetails":{
-                  "hasPaymentDetails":true,
-                  "__typename":"PaymentDetails"
-               },
-               "canStartTrial":true,
-               "subscription":{
-                  "quantity": 1,
-                  "interval":"month",
-                  "periodEnd":null,
-                  "isCanceledAtPeriodEnd":false,
-                  "trial":null,
-                  "plan":{
-                    "id": "essentials",
-                    "name": "Essentials",
-                     "__typename":"OBPlan"
-                  },
-                  "__typename":"OBSubscription"
-               },
-               "changePlanOptions":[
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":6,
-                     "totalPrice":6,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":12,
-                     "totalPrice":12,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":true,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"0% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":5,
-                     "totalPrice":60,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":10,
-                     "totalPrice":120,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":true,
-                     "downgradedMessage":"",
-                    "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  }
-               ],
-               "__typename":"OBBilling"
+            "canStartTrial": true,
+            "subscription": {
+              "quantity": 1,
+              "interval": "month",
+              "periodEnd": null,
+              "isCanceledAtPeriodEnd": false,
+              "trial": null,
+              "plan": {
+                "id": "essentials",
+                "name": "Essentials",
+                "__typename": "OBPlan"
+              },
+              "__typename": "OBSubscription"
             },
-            "__typename":"AccountOrganization"
-         },
-         "organizations":[
-            {
-               "id":"606b65d6dad38c03d2b70793",
-               "name":"test",
-               "canEdit":true,
-               "role":"admin",
-               "canMigrateToOneBuffer": {
-                  "canMigrate": false,
-                  "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-                  "__typename": "CanMigrateToOneBuffer"
-               },
-               "createdAt":"2021-04-05T19:32:38.961Z",
-               "isOneBufferOrganization":true,
-               "shouldDisplayInviteCTA":false,
-               "featureFlips":[
-                  "grantAnalyzeAccess",
-                  "sharedChannels",
-                  "engageRollOut"
-               ],
-               "channels":[
-               ],
-               "billing":{
-                  "id":"606b65d6dad38c03d2b70793",
-                  "canAccessAnalytics":false,
-                  "canAccessEngagement":false,
-                  "canAccessPublishing":true,
-                  "paymentDetails":{
-                     "hasPaymentDetails":true,
-                     "__typename":"PaymentDetails"
-                  },
-                  "canStartTrial":true,
-                  "subscription":{
-                     "quantity":1,
-                     "interval":"month",
-                     "periodEnd":null,
-                     "isCanceledAtPeriodEnd":false,
-                     "trial":null,
-                     "plan":{
-                        "id": "essentials",
-                        "name": "Essentials",
-                        "__typename":"OBPlan"
-                     },
-                     "__typename":"OBSubscription"
-                  },
-                  "changePlanOptions":[
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":6,
-                        "totalPrice":6,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":12,
-                        "totalPrice":12,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":true,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"0% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":5,
-                        "totalPrice":60,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":10,
-                        "totalPrice":120,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":true,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     }
+            "changePlanOptions": [
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": true,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
                   ],
-                  "__typename":"OBBilling"
-               },
-               "__typename":"AccountOrganization"
-            }
-         ],
-         "products":[
-            {
-               "name":"publish",
-               "userId":"606b65d760292104ad6ef6b5",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"analyze",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"engage",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            }
-         ],
-         "__typename":"Account"
-      }
-   }
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 6,
+                "totalPrice": 6,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 12,
+                "totalPrice": 12,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": true,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": true,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "0% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 5,
+                "totalPrice": 60,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": true,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              }
+            ],
+            "__typename": "OBBilling"
+          },
+          "__typename": "AccountOrganization"
+        }
+      ],
+      "products": [
+        {
+          "name": "publish",
+          "userId": "606b65d760292104ad6ef6b5",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "analyze",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "engage",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        }
+      ],
+      "__typename": "Account"
+    }
+  }
 }

--- a/cypress/fixtures/accountObFree.json
+++ b/cypress/fixtures/accountObFree.json
@@ -1,622 +1,615 @@
 {
-   "data":{
-      "account":{
-         "id":"606b65d6dad38c9d20b70792",
-         "email":"ob_free@buffer.com",
-         "createdAt":"2021-04-05T19:32:38.841Z",
-         "featureFlips":[
+  "data": {
+    "account": {
+      "id": "606b65d6dad38c9d20b70792",
+      "email": "ob_free@buffer.com",
+      "createdAt": "2021-04-05T19:32:38.841Z",
+      "featureFlips": [
+        "grantAnalyzeAccess",
+        "sharedChannels",
+        "engageRollOut",
+        "geid1_free_user_trial_prompt"
+      ],
+      "isImpersonation": false,
+      "shouldShowEmailVerificationCommunication": true,
+      "currentOrganization": {
+        "id": "606b65d6dad38c03d2b70793",
+        "name": "test",
+        "canEdit": true,
+        "role": "admin",
+        "canMigrateToOneBuffer": {
+          "canMigrate": false,
+          "reasons": [
+            "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+          ],
+          "__typename": "CanMigrateToOneBuffer"
+        },
+        "createdAt": "2021-04-05T19:32:38.961Z",
+        "isOneBufferOrganization": true,
+        "shouldDisplayInviteCTA": false,
+        "featureFlips": [
+          "grantAnalyzeAccess",
+          "sharedChannels",
+          "engageRollOut",
+          "geid1_free_user_trial_prompt"
+        ],
+        "channels": [
+          {
+            "id": "606b65e1dd934f70840bfef7",
+            "__typename": "Channel"
+          }
+        ],
+        "billing": {
+          "id": "606b65d6dad38c03d2b70793",
+          "canAccessAnalytics": false,
+          "canAccessEngagement": false,
+          "canAccessPublishing": true,
+          "paymentDetails": {
+            "hasPaymentDetails": true,
+            "__typename": "PaymentDetails"
+          },
+          "canStartTrial": true,
+          "subscription": {
+            "quantity": 1,
+            "interval": "month",
+            "periodEnd": null,
+            "isCanceledAtPeriodEnd": false,
+            "trial": null,
+            "plan": {
+              "id": "free",
+              "name": "Free",
+              "__typename": "OBPlan"
+            },
+            "__typename": "OBSubscription"
+          },
+          "changePlanOptions": [
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": true,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 6,
+              "totalPrice": 6,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 12,
+              "totalPrice": 12,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": true,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": true,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "0% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 5,
+              "totalPrice": 60,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 10,
+              "totalPrice": 120,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": true,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            }
+          ],
+          "__typename": "OBBilling"
+        },
+        "__typename": "AccountOrganization"
+      },
+      "organizations": [
+        {
+          "id": "606b65d6dad38c03d2b70793",
+          "name": "test",
+          "canEdit": true,
+          "role": "admin",
+          "canMigrateToOneBuffer": {
+            "canMigrate": false,
+            "reasons": [
+              "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+            ],
+            "__typename": "CanMigrateToOneBuffer"
+          },
+          "createdAt": "2021-04-05T19:32:38.961Z",
+          "isOneBufferOrganization": true,
+          "shouldDisplayInviteCTA": false,
+          "featureFlips": [
             "grantAnalyzeAccess",
             "sharedChannels",
-            "engageRollOut",
-            "geid1_free_user_trial_prompt"
-         ],
-         "isImpersonation":false,
-         "currentOrganization":{
-            "id":"606b65d6dad38c03d2b70793",
-            "name":"test",
-            "canEdit":true,
-            "role":"admin",
-            "canMigrateToOneBuffer": {
-               "canMigrate": false,
-               "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-               "__typename": "CanMigrateToOneBuffer"
+            "engageRollOut"
+          ],
+          "channels": [
+            {
+              "id": "606b65e1dd934f70840bfef7",
+              "name": "testing public",
+              "service": "facebook",
+              "organizationId": "606b65d6dad38c03d2b70793",
+              "__typename": "Channel"
+            }
+          ],
+          "billing": {
+            "id": "606b65d6dad38c03d2b70793",
+            "canAccessAnalytics": false,
+            "canAccessEngagement": false,
+            "canAccessPublishing": true,
+            "paymentDetails": {
+              "hasPaymentDetails": true,
+              "__typename": "PaymentDetails"
             },
-            "createdAt":"2021-04-05T19:32:38.961Z",
-            "isOneBufferOrganization":true,
-            "shouldDisplayInviteCTA":false,
-            "featureFlips":[
-               "grantAnalyzeAccess",
-               "sharedChannels",
-               "engageRollOut",
-               "geid1_free_user_trial_prompt"
-            ],
-            "channels":[
+            "canStartTrial": true,
+            "subscription": {
+              "quantity": 1,
+              "interval": "month",
+              "periodEnd": null,
+              "isCanceledAtPeriodEnd": false,
+              "trial": null,
+              "plan": {
+                "id": "free",
+                "name": "Free",
+                "__typename": "OBPlan"
+              },
+              "__typename": "OBSubscription"
+            },
+            "changePlanOptions": [
               {
-                "id":"606b65e1dd934f70840bfef7",
-                "__typename":"Channel"
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": true,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 6,
+                "totalPrice": 6,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 12,
+                "totalPrice": 12,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": true,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": true,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "0% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 5,
+                "totalPrice": 60,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": true,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
               }
             ],
-            "billing":{
-               "id":"606b65d6dad38c03d2b70793",
-               "canAccessAnalytics":false,
-               "canAccessEngagement":false,
-               "canAccessPublishing":true,
-               "paymentDetails":{
-                  "hasPaymentDetails":true,
-                  "__typename":"PaymentDetails"
-               },
-               "canStartTrial":true,
-               "subscription":{
-                  "quantity": 1,
-                  "interval":"month",
-                  "periodEnd":null,
-                  "isCanceledAtPeriodEnd":false,
-                  "trial":null,
-                  "plan":{
-                     "id":"free",
-                     "name":"Free",
-                     "__typename":"OBPlan"
-                  },
-                  "__typename":"OBSubscription"
-               },
-               "changePlanOptions":[
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":6,
-                     "totalPrice":6,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":12,
-                     "totalPrice":12,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":true,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"0% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":5,
-                     "totalPrice":60,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":10,
-                     "totalPrice":120,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":true,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  }
-               ],
-               "__typename":"OBBilling"
-            },
-            "__typename":"AccountOrganization"
-         },
-         "organizations":[
-            {
-               "id":"606b65d6dad38c03d2b70793",
-               "name":"test",
-               "canEdit":true,
-               "role":"admin",
-               "canMigrateToOneBuffer": {
-                  "canMigrate": false,
-                  "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-                  "__typename": "CanMigrateToOneBuffer"
-               },
-               "createdAt":"2021-04-05T19:32:38.961Z",
-               "isOneBufferOrganization":true,
-               "shouldDisplayInviteCTA":false,
-               "featureFlips":[
-                  "grantAnalyzeAccess",
-                  "sharedChannels",
-                  "engageRollOut"
-               ],
-               "channels":[
-                  {
-                     "id":"606b65e1dd934f70840bfef7",
-                     "name":"testing public",
-                     "service":"facebook",
-                     "organizationId":"606b65d6dad38c03d2b70793",
-                     "__typename":"Channel"
-                  }
-               ],
-               "billing":{
-                  "id":"606b65d6dad38c03d2b70793",
-                  "canAccessAnalytics":false,
-                  "canAccessEngagement":false,
-                  "canAccessPublishing":true,
-                  "paymentDetails":{
-                     "hasPaymentDetails":true,
-                     "__typename":"PaymentDetails"
-                  },
-                  "canStartTrial":true,
-                  "subscription":{
-                     "quantity":1,
-                     "interval":"month",
-                     "periodEnd":null,
-                     "isCanceledAtPeriodEnd":false,
-                     "trial":null,
-                     "plan":{
-                        "id":"free",
-                        "name":"Free",
-                        "__typename":"OBPlan"
-                     },
-                     "__typename":"OBSubscription"
-                  },
-                  "changePlanOptions":[
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":6,
-                        "totalPrice":6,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":12,
-                        "totalPrice":12,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":true,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"0% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":5,
-                        "totalPrice":60,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":10,
-                        "totalPrice":120,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":true,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     }
-                  ],
-                  "__typename":"OBBilling"
-               },
-               "__typename":"AccountOrganization"
-            }
-         ],
-         "products":[
-            {
-               "name":"publish",
-               "userId":"606b65d760292104ad6ef6b5",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"analyze",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"engage",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            }
-         ],
-         "__typename":"Account"
-      }
-   }
+            "__typename": "OBBilling"
+          },
+          "__typename": "AccountOrganization"
+        }
+      ],
+      "products": [
+        {
+          "name": "publish",
+          "userId": "606b65d760292104ad6ef6b5",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "analyze",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "engage",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        }
+      ],
+      "__typename": "Account"
+    }
+  }
 }

--- a/cypress/fixtures/accountObTeam.json
+++ b/cypress/fixtures/accountObTeam.json
@@ -1,620 +1,609 @@
 {
-   "data":{
-      "account":{
-         "id":"606b65d6dad38c9d20b70792",
-         "email":"federico+obfree@buffer.com",
-         "createdAt":"2021-04-05T19:32:38.841Z",
-         "featureFlips":[
+  "data": {
+    "account": {
+      "id": "606b65d6dad38c9d20b70792",
+      "email": "federico+obfree@buffer.com",
+      "createdAt": "2021-04-05T19:32:38.841Z",
+      "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
+      "isImpersonation": false,
+      "shouldShowEmailVerificationCommunication": true,
+      "currentOrganization": {
+        "id": "606b65d6dad38c03d2b70793",
+        "name": "test",
+        "canEdit": true,
+        "role": "admin",
+        "canMigrateToOneBuffer": {
+          "canMigrate": false,
+          "reasons": [
+            "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+          ],
+          "__typename": "CanMigrateToOneBuffer"
+        },
+        "createdAt": "2021-04-05T19:32:38.961Z",
+        "isOneBufferOrganization": true,
+        "shouldDisplayInviteCTA": true,
+        "featureFlips": [
+          "grantAnalyzeAccess",
+          "sharedChannels",
+          "engageRollOut"
+        ],
+        "channels": [
+          {
+            "id": "606b65e1dd934f70840bfef7",
+            "__typename": "Channel"
+          }
+        ],
+        "billing": {
+          "id": "606b65d6dad38c03d2b70793",
+          "canAccessAnalytics": true,
+          "canAccessEngagement": true,
+          "canAccessPublishing": true,
+          "paymentDetails": {
+            "hasPaymentDetails": true,
+            "__typename": "PaymentDetails"
+          },
+          "canStartTrial": false,
+          "subscription": {
+            "quantity": 1,
+            "interval": "year",
+            "periodEnd": "2022-08-11T17:58:29.000Z",
+            "isCanceledAtPeriodEnd": false,
+            "trial": null,
+            "plan": {
+              "id": "team",
+              "name": "Essentials + Team Pack",
+              "__typename": "OBPlan"
+            },
+            "__typename": "OBSubscription"
+          },
+          "changePlanOptions": [
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": false,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 6,
+              "totalPrice": 6,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "month",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 12,
+              "totalPrice": 12,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Save $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "free",
+              "planName": "Free",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Simplify the noise and test out social media management tools.",
+              "isCurrentPlan": false,
+              "highlights": ["Basic publishing tools", "Limited usage"],
+              "currency": "$",
+              "basePrice": 0,
+              "totalPrice": 0,
+              "discountPercentage": 0,
+              "discountNote": "0% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "",
+              "summary": {
+                "details": [
+                  "10 scheduled posts",
+                  "3 social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "essentials",
+              "planName": "Essentials",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools"
+              ],
+              "currency": "$",
+              "basePrice": 5,
+              "totalPrice": 60,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $12/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "One user"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "team",
+              "planName": "Essentials + Team Pack",
+              "planInterval": "year",
+              "channelsQuantity": 1,
+              "description": "Collaborate with your team in one place & save time reporting.",
+              "isCurrentPlan": true,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Drafting & approval workflow tools",
+                "Exportable PDF reports"
+              ],
+              "currency": "$",
+              "basePrice": 10,
+              "totalPrice": 120,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "Per social channel per month",
+              "absoluteSavings": "Saving $24/year",
+              "summary": {
+                "details": [
+                  "Unlimited scheduled posts",
+                  "Unlimited social channels",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 0,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 0,
+                "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            }
+          ],
+          "__typename": "OBBilling"
+        },
+        "__typename": "AccountOrganization"
+      },
+      "organizations": [
+        {
+          "id": "606b65d6dad38c03d2b70793",
+          "name": "test",
+          "canEdit": true,
+          "role": "admin",
+          "canMigrateToOneBuffer": {
+            "canMigrate": false,
+            "reasons": [
+              "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+            ],
+            "__typename": "CanMigrateToOneBuffer"
+          },
+          "createdAt": "2021-04-05T19:32:38.961Z",
+          "isOneBufferOrganization": true,
+          "shouldDisplayInviteCTA": true,
+          "featureFlips": [
             "grantAnalyzeAccess",
             "sharedChannels",
             "engageRollOut"
-         ],
-         "isImpersonation":false,
-         "currentOrganization":{
-            "id":"606b65d6dad38c03d2b70793",
-            "name":"test",
-            "canEdit":true,
-            "role":"admin",
-            "canMigrateToOneBuffer": {
-               "canMigrate": false,
-               "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-               "__typename": "CanMigrateToOneBuffer"
+          ],
+          "channels": [
+            {
+              "id": "606b65e1dd934f70840bfef7",
+              "name": "testing public",
+              "service": "facebook",
+              "organizationId": "606b65d6dad38c03d2b70793",
+              "__typename": "Channel"
+            }
+          ],
+          "billing": {
+            "id": "606b65d6dad38c03d2b70793",
+            "canAccessAnalytics": true,
+            "canAccessEngagement": true,
+            "canAccessPublishing": true,
+            "paymentDetails": {
+              "hasPaymentDetails": true,
+              "__typename": "PaymentDetails"
             },
-            "createdAt":"2021-04-05T19:32:38.961Z",
-            "isOneBufferOrganization":true,
-            "shouldDisplayInviteCTA":true,
-            "featureFlips":[
-               "grantAnalyzeAccess",
-               "sharedChannels",
-               "engageRollOut"
-            ],
-            "channels":[
+            "canStartTrial": false,
+            "subscription": {
+              "quantity": 1,
+              "interval": "year",
+              "periodEnd": "2022-08-11T17:58:29.000Z",
+              "isCanceledAtPeriodEnd": false,
+              "trial": null,
+              "plan": {
+                "id": "team",
+                "name": "Essentials + Team Pack",
+                "__typename": "OBPlan"
+              },
+              "__typename": "OBSubscription"
+            },
+            "changePlanOptions": [
               {
-                "id":"606b65e1dd934f70840bfef7",
-                "__typename":"Channel"
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 6,
+                "totalPrice": 6,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 12,
+                "totalPrice": 12,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "0% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 5,
+                "totalPrice": 60,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": true,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
               }
             ],
-            "billing":{
-               "id":"606b65d6dad38c03d2b70793",
-               "canAccessAnalytics":true,
-               "canAccessEngagement":true,
-               "canAccessPublishing":true,
-               "paymentDetails":{
-                  "hasPaymentDetails":true,
-                  "__typename":"PaymentDetails"
-               },
-               "canStartTrial":false,
-               "subscription":{
-                  "quantity": 1,
-                  "interval":"year",
-                  "periodEnd":"2022-08-11T17:58:29.000Z",
-                  "isCanceledAtPeriodEnd":false,
-                  "trial":null,
-                  "plan":{
-                     "id":"team",
-                     "name":"Essentials + Team Pack",
-                     "__typename":"OBPlan"
-                  },
-                  "__typename":"OBSubscription"
-               },
-               "changePlanOptions":[
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":6,
-                     "totalPrice":6,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"month",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":12,
-                     "totalPrice":12,
-                     "discountPercentage":0,
-                     "discountNote":"",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Save $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"free",
-                     "planName":"Free",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Simplify the noise and test out social media management tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Basic publishing tools",
-                        "Limited usage"
-                     ],
-                     "currency":"$",
-                     "basePrice":0,
-                     "totalPrice":0,
-                     "discountPercentage":0,
-                     "discountNote":"0% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"",
-                     "summary":{
-                        "details":[
-                           "10 scheduled posts",
-                           "3 social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"essentials",
-                     "planName":"Essentials",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                     "isCurrentPlan":false,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools"
-                     ],
-                     "currency":"$",
-                     "basePrice":5,
-                     "totalPrice":60,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $12/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "One user"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  },
-                  {
-                     "planId":"team",
-                     "planName":"Essentials + Team Pack",
-                     "planInterval":"year",
-                     "channelsQuantity":1,
-                     "description":"Collaborate with your team in one place & save time reporting.",
-                     "isCurrentPlan":true,
-                     "highlights":[
-                        "Advanced publishing tools",
-                        "Analytics & reporting",
-                        "Engagement tools",
-                        "Unlimited team members & clients",
-                        "Drafting & approval workflow tools",
-                        "Exportable PDF reports"
-                     ],
-                     "currency":"$",
-                     "basePrice":10,
-                     "totalPrice":120,
-                     "discountPercentage":17,
-                     "discountNote":"17% Discount",
-                     "priceNote":"Per social channel per month",
-                     "absoluteSavings":"Saving $24/year",
-                     "summary":{
-                        "details":[
-                           "Unlimited scheduled posts",
-                           "Unlimited social channels",
-                           "Unlimited users"
-                        ],
-                        "__typename":"OBPlanOptionSummary"
-                     },
-                     "isRecommended":false,
-                     "downgradedMessage":"",
-                     "channelSlotDetails":{
-                        "flatFee":0, 
-                        "currentQuantity":0, 
-                        "chargableQuantity":0, 
-                        "pricePerQuantity":0, 
-                        "minimumQuantity":0,
-                        "__typename": "ChannelSlotDetails"
-                     },
-                     "__typename":"OBPlanOption"
-                  }
-               ],
-               "__typename":"OBBilling"
-            },
-            "__typename":"AccountOrganization"
-         },
-         "organizations":[
-            {
-               "id":"606b65d6dad38c03d2b70793",
-               "name":"test",
-               "canEdit":true,
-               "role":"admin",
-               "canMigrateToOneBuffer": {
-                  "canMigrate": false,
-                  "reasons": ["Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"],
-                  "__typename": "CanMigrateToOneBuffer"
-               },
-               "createdAt":"2021-04-05T19:32:38.961Z",
-               "isOneBufferOrganization":true,
-               "shouldDisplayInviteCTA":true,
-               "featureFlips":[
-                  "grantAnalyzeAccess",
-                  "sharedChannels",
-                  "engageRollOut"
-               ],
-               "channels":[
-                  {
-                     "id":"606b65e1dd934f70840bfef7",
-                     "name":"testing public",
-                     "service":"facebook",
-                     "organizationId":"606b65d6dad38c03d2b70793",
-                     "__typename":"Channel"
-                  }
-               ],
-               "billing":{
-                  "id":"606b65d6dad38c03d2b70793",
-                  "canAccessAnalytics":true,
-                  "canAccessEngagement":true,
-                  "canAccessPublishing":true,
-                  "paymentDetails":{
-                     "hasPaymentDetails":true,
-                     "__typename":"PaymentDetails"
-                  },
-                  "canStartTrial":false,
-                  "subscription":{
-                     "quantity": 1,
-                     "interval":"year",
-                     "periodEnd":"2022-08-11T17:58:29.000Z",
-                     "isCanceledAtPeriodEnd":false,
-                     "trial":null,
-                     "plan":{
-                        "id":"team",
-                        "name":"Essentials + Team Pack",
-                        "__typename":"OBPlan"
-                     },
-                     "__typename":"OBSubscription"
-                  },
-                  "changePlanOptions":[
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":6,
-                        "totalPrice":6,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"month",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":12,
-                        "totalPrice":12,
-                        "discountPercentage":0,
-                        "discountNote":"",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Save $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"free",
-                        "planName":"Free",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Simplify the noise and test out social media management tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Basic publishing tools",
-                           "Limited usage"
-                        ],
-                        "currency":"$",
-                        "basePrice":0,
-                        "totalPrice":0,
-                        "discountPercentage":0,
-                        "discountNote":"0% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"",
-                        "summary":{
-                           "details":[
-                              "10 scheduled posts",
-                              "3 social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"essentials",
-                        "planName":"Essentials",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Get the most out of your creative with publishing, analytics & engagement tools.",
-                        "isCurrentPlan":false,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools"
-                        ],
-                        "currency":"$",
-                        "basePrice":5,
-                        "totalPrice":60,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $12/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "One user"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     },
-                     {
-                        "planId":"team",
-                        "planName":"Essentials + Team Pack",
-                        "planInterval":"year",
-                        "channelsQuantity":1,
-                        "description":"Collaborate with your team in one place & save time reporting.",
-                        "isCurrentPlan":true,
-                        "highlights":[
-                           "Advanced publishing tools",
-                           "Analytics & reporting",
-                           "Engagement tools",
-                           "Unlimited team members & clients",
-                           "Drafting & approval workflow tools",
-                           "Exportable PDF reports"
-                        ],
-                        "currency":"$",
-                        "basePrice":10,
-                        "totalPrice":120,
-                        "discountPercentage":17,
-                        "discountNote":"17% Discount",
-                        "priceNote":"Per social channel per month",
-                        "absoluteSavings":"Saving $24/year",
-                        "summary":{
-                           "details":[
-                              "Unlimited scheduled posts",
-                              "Unlimited social channels",
-                              "Unlimited users"
-                           ],
-                           "__typename":"OBPlanOptionSummary"
-                        },
-                        "isRecommended":false,
-                        "downgradedMessage":"",
-                        "channelSlotDetails":{
-                           "flatFee":0, 
-                           "currentQuantity":0, 
-                           "chargableQuantity":0, 
-                           "pricePerQuantity":0, 
-                           "minimumQuantity":0,
-                           "__typename": "ChannelSlotDetails"
-                        },
-                        "__typename":"OBPlanOption"
-                     }
-                  ],
-                  "__typename":"OBBilling"
-               },
-               "__typename":"AccountOrganization"
-            }
-         ],
-         "products":[
-            {
-               "name":"publish",
-               "userId":"606b65d760292104ad6ef6b5",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"analyze",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            },
-            {
-               "name":"engage",
-               "userId":"606b65d6dad38c9d20b70792",
-               "__typename":"ProductLink"
-            }
-         ],
-         "__typename":"Account"
-      }
-   }
+            "__typename": "OBBilling"
+          },
+          "__typename": "AccountOrganization"
+        }
+      ],
+      "products": [
+        {
+          "name": "publish",
+          "userId": "606b65d760292104ad6ef6b5",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "analyze",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        },
+        {
+          "name": "engage",
+          "userId": "606b65d6dad38c9d20b70792",
+          "__typename": "ProductLink"
+        }
+      ],
+      "__typename": "Account"
+    }
+  }
 }

--- a/packages/app-shell/src/common/graphql/account.js
+++ b/packages/app-shell/src/common/graphql/account.js
@@ -6,6 +6,19 @@ export const SET_CURRENT_ORGANIZATION = gql`
   }
 `;
 
+export const ACCOUNT_INITIATE_EMAIL_VERIFICATION = gql`
+  mutation AccountInitiateEmailVerification {
+    accountInitiateEmailVerification {
+      ... on AccountInitiateEmailVerificationResponse {
+        success
+      }
+      ... on AccountInitiateEmailVerificationError {
+        userFriendlyMessage
+      }
+    }
+  }
+`;
+
 export const BILLING_FIELDS = gql`
   fragment BillingFields on Billing {
     id
@@ -86,6 +99,7 @@ export const QUERY_ACCOUNT = gql`
       createdAt
       featureFlips
       isImpersonation
+      shouldShowEmailVerificationCommunication
       currentOrganization {
         id
         name

--- a/packages/app-shell/src/common/hooks/useEmailVerification.js
+++ b/packages/app-shell/src/common/hooks/useEmailVerification.js
@@ -1,0 +1,39 @@
+import { useMutation } from '@apollo/client';
+import { ACCOUNT_INITIATE_EMAIL_VERIFICATION } from '../graphql/account';
+
+const useEmailVerification = () => {
+  const [initiateEmailVerification, { data, error }] = useMutation(
+    ACCOUNT_INITIATE_EMAIL_VERIFICATION
+  );
+
+  let bannerOptions;
+
+  if (data) {
+    // Success after re-send verification email attempt
+    bannerOptions = {
+      text: 'We just sent you an email! Please check your inbox to complete verification steps.',
+      actionButton: {},
+    };
+  } else if (error) {
+    // Error during the re-send verification email attempt
+    bannerOptions = {
+      text: error.accountInitiateEmailVerificationError?.userFriendlyMessage,
+      actionButton: {},
+    };
+  } else {
+    // Email verification needed
+    bannerOptions = {
+      text: 'Please verify your email address.',
+      actionButton: {
+        action: initiateEmailVerification,
+        label: 'Re-send verification email',
+      },
+    };
+  }
+
+  return {
+    bannerOptions,
+  };
+};
+
+export default useEmailVerification;

--- a/packages/app-shell/src/common/hooks/useEmailVerification.js
+++ b/packages/app-shell/src/common/hooks/useEmailVerification.js
@@ -7,6 +7,7 @@ const useEmailVerification = () => {
   );
 
   let bannerOptions;
+  let renderCustomHTML;
 
   if (data) {
     // Success after re-send verification email attempt
@@ -23,16 +24,17 @@ const useEmailVerification = () => {
   } else {
     // Email verification needed
     bannerOptions = {
-      text: 'Please verify your email address.',
       actionButton: {
         action: initiateEmailVerification,
         label: 'Re-send verification email',
       },
     };
+    renderCustomHTML = true;
   }
 
   return {
     bannerOptions,
+    renderCustomHTML,
   };
 };
 

--- a/packages/app-shell/src/components/Banner/index.jsx
+++ b/packages/app-shell/src/components/Banner/index.jsx
@@ -60,12 +60,13 @@ export default class Banner extends React.Component {
 
   render() {
     const { isOpen } = this.state;
-    const { themeColor } = this.props;
+    const { themeColor, dismissable } = this.props;
 
     if (isOpen) {
       return (
         <BannerStyled themeColor={themeColor}>
           {this.renderBannerContent(themeColor)}
+          {dismissable && (
           <BannerCloseButton>
             <Button
               type="text"
@@ -80,6 +81,7 @@ export default class Banner extends React.Component {
               size="small"
             />
           </BannerCloseButton>
+          )}
         </BannerStyled>
       );
     }
@@ -105,6 +107,9 @@ Banner.propTypes = {
 
   /** Handler when the banner closes */
   onCloseBanner: PropTypes.func,
+
+  /** Allow functionality to dismiss banner **/
+  dismissable: PropTypes.bool,
 };
 
 Banner.defaultProps = {
@@ -113,4 +118,5 @@ Banner.defaultProps = {
   customHTML: null,
   themeColor: 'blue',
   onCloseBanner: null,
+  dismissable: true,
 };

--- a/packages/app-shell/src/components/Banner/index.jsx
+++ b/packages/app-shell/src/components/Banner/index.jsx
@@ -47,12 +47,14 @@ export default class Banner extends React.Component {
           {text}
         </Text>
         <ButtonWrapper>
-          <Button
-            type={themeColor === 'orange' ? 'orange' : 'primary'}
-            onClick={actionButton.action}
-            label={actionButton.label}
-            size="small"
-          />
+          {actionButton.label && actionButton.action && (
+            <Button
+              type={themeColor === 'orange' ? 'orange' : 'primary'}
+              onClick={actionButton.action}
+              label={actionButton.label}
+              size="small"
+            />
+          )}
         </ButtonWrapper>
       </Wrapper>
     );
@@ -67,20 +69,20 @@ export default class Banner extends React.Component {
         <BannerStyled themeColor={themeColor}>
           {this.renderBannerContent(themeColor)}
           {dismissable && (
-          <BannerCloseButton>
-            <Button
-              type="text"
-              icon={
-                <CrossIcon
-                  color={themeColor === 'blue' ? '#fff' : orangeDark}
-                />
-              }
-              hasIconOnly
-              onClick={this.closeBanner}
-              label="Close"
-              size="small"
-            />
-          </BannerCloseButton>
+            <BannerCloseButton>
+              <Button
+                type="text"
+                icon={
+                  <CrossIcon
+                    color={themeColor === 'blue' ? '#fff' : orangeDark}
+                  />
+                }
+                hasIconOnly
+                onClick={this.closeBanner}
+                label="Close"
+                size="small"
+              />
+            </BannerCloseButton>
           )}
         </BannerStyled>
       );

--- a/packages/app-shell/src/components/Banner/index.jsx
+++ b/packages/app-shell/src/components/Banner/index.jsx
@@ -34,12 +34,7 @@ export default class Banner extends React.Component {
   renderBannerContent(themeColor) {
     const { customHTML, text, actionButton } = this.props;
     if (customHTML) {
-      return (
-        <Wrapper>
-          {/* eslint-disable-next-line */}
-          <div dangerouslySetInnerHTML={customHTML} />
-        </Wrapper>
-      );
+      return <Wrapper>{customHTML}</Wrapper>;
     }
     return (
       <Wrapper>

--- a/packages/app-shell/src/components/Banner/index.jsx
+++ b/packages/app-shell/src/components/Banner/index.jsx
@@ -62,13 +62,13 @@ export default class Banner extends React.Component {
 
   render() {
     const { isOpen } = this.state;
-    const { themeColor, dismissable } = this.props;
+    const { themeColor, dismissible } = this.props;
 
     if (isOpen) {
       return (
         <BannerStyled themeColor={themeColor}>
           {this.renderBannerContent(themeColor)}
-          {dismissable && (
+          {dismissible && (
             <BannerCloseButton>
               <Button
                 type="text"
@@ -111,7 +111,7 @@ Banner.propTypes = {
   onCloseBanner: PropTypes.func,
 
   /** Allow functionality to dismiss banner **/
-  dismissable: PropTypes.bool,
+  dismissible: PropTypes.bool,
 };
 
 Banner.defaultProps = {
@@ -120,5 +120,5 @@ Banner.defaultProps = {
   customHTML: null,
   themeColor: 'blue',
   onCloseBanner: null,
-  dismissable: true,
+  dismissible: true,
 };

--- a/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
+++ b/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
@@ -11,6 +11,7 @@ const EmailVerificationBanner = () => {
   const { bannerOptions, renderCustomHTML } = useEmailVerification();
 
   if (renderCustomHTML) {
+    //  We need to render custom HTML as we're using a link, rather than text.
     return (
       <Banner
         themeColor="orange"
@@ -18,8 +19,15 @@ const EmailVerificationBanner = () => {
         customHTML={
           <>
             <Text type="paragraph" color="#fff">
-              Please verify your email address. Check out our{' '}
-              <a href="">help guide</a> to read more.
+              Please verify your email address. You can visit our{' '}
+              <a
+                href="https://support.buffer.com/hc/en-us/articles/4563021461907-Verifying-your-Buffer-email-address"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                help guide
+              </a>{' '}
+              for more info.
             </Text>
             <Styles.ButtonWrapper>
               <Button

--- a/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
+++ b/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Button from '@bufferapp/ui/Button';
+import Text from '@bufferapp/ui/Text';
+
+import Banner from '../../../../components/Banner';
+import useEmailVerification from '../../../../common/hooks/useEmailVerification';
+
+import * as Styles from './styles';
+
+const EmailVerificationBanner = () => {
+  const { bannerOptions, renderCustomHTML } = useEmailVerification();
+
+  if (renderCustomHTML) {
+    return (
+      <Banner
+        themeColor="orange"
+        dismissible={false}
+        customHTML={
+          <>
+            <Text type="paragraph" color="#fff">
+              Please verify your email address. Check out our{' '}
+              <a href="">help guide</a> to read more.
+            </Text>
+            <Styles.ButtonWrapper>
+              <Button
+                type="orange"
+                onClick={bannerOptions.actionButton.action}
+                label={bannerOptions.actionButton.label}
+                size="small"
+              />
+            </Styles.ButtonWrapper>
+          </>
+        }
+      />
+    );
+  }
+
+  return (
+    <Banner
+      themeColor="orange"
+      text={bannerOptions.text}
+      actionButton={bannerOptions.actionButton}
+      dismissible={false}
+    />
+  );
+};
+
+export default EmailVerificationBanner;

--- a/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/index.js
+++ b/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/index.js
@@ -1,0 +1,1 @@
+export { default } from './EmailVerificationBanner';

--- a/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/styles.js
+++ b/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/styles.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const ButtonWrapper = styled.div`
+  margin-left: 8px;
+`;

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -147,7 +147,7 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
                     action: () => initiateEmailVerification(),
                   }
             }
-            dismissable={false}
+            dismissible={false}
           />
         )}
         {!user.loading && <Modal {...modal} />}

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -137,13 +137,13 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
             text={
               resendEmailVerificationSuccess
                 ? 'Please check your inbox to verify your email'
-                : 'Please verify your email address. Contact support@buffer.com for help.'
+                : 'Please verify your email address. Contact support for help.'
             }
             actionButton={
               resendEmailVerificationSuccess
                 ? {}
                 : {
-                    label: 'Re-send Verification Email',
+                    label: 'Re-send verification email',
                     action: () => initiateEmailVerification(),
                   }
             }

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -97,7 +97,7 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
   const showEmailVerificationBanner =
     !loading && user.shouldShowEmailVerificationCommunication;
   const { bannerOptions } = useEmailVerification();
-  console.log(bannerOptions);
+
   return (
     <UserContext.Provider value={user}>
       <ModalContext.Provider value={modal}>

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -6,6 +6,7 @@ import {
   ApolloClient,
   InMemoryCache,
   useQuery,
+  useMutation,
   HttpLink,
 } from '@apollo/client';
 import ReactDOM from 'react-dom';
@@ -17,7 +18,10 @@ import Modal from '../../components/Modal/index';
 import { UserContext } from '../../common/context/User';
 import { ModalContext } from '../../common/context/Modal';
 import useModal, { MODALS } from '../../common/hooks/useModal';
-import { QUERY_ACCOUNT } from '../../common/graphql/account';
+import {
+  QUERY_ACCOUNT,
+  ACCOUNT_INITIATE_EMAIL_VERIFICATION,
+} from '../../common/graphql/account';
 import useUserTracker from '../../common/hooks/useUserTracker';
 import getTrialBannerCopy from './getTrialBannerCopy';
 import ErrorBoundary from './ErrorBoundary';
@@ -93,6 +97,20 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
     }
   }
 
+  const [
+    initiateEmailVerification,
+    {
+      data: initiateEmailVerificationData,
+      error: initiateEmailVerificationError,
+    },
+  ] = useMutation(ACCOUNT_INITIATE_EMAIL_VERIFICATION);
+
+  // Email verification banner
+  const showEmailVerificationBanner =
+    !loading && user.shouldShowEmailVerificationCommunication;
+  const resendEmailVerificationSuccess =
+    initiateEmailVerificationData?.accountInitiateEmailVerification?.success;
+
   return (
     <UserContext.Provider value={user}>
       <ModalContext.Provider value={modal}>
@@ -112,6 +130,24 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
                   isUpgradeIntent: true,
                 }),
             }}
+          />
+        )}
+        {showEmailVerificationBanner && (
+          <Banner
+            text={
+              resendEmailVerificationSuccess
+                ? 'Please check your inbox to verify your email'
+                : 'Please verify your email address. Contact support@buffer.com for help.'
+            }
+            actionButton={
+              resendEmailVerificationSuccess
+                ? {}
+                : {
+                    label: 'Re-send Verification Email',
+                    action: () => initiateEmailVerification(),
+                  }
+            }
+            dismissable={false}
           />
         )}
         {!user.loading && <Modal {...modal} />}

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -22,6 +22,7 @@ import useUserTracker from '../../common/hooks/useUserTracker';
 import useEmailVerification from '../../common/hooks/useEmailVerification';
 import getTrialBannerCopy from './getTrialBannerCopy';
 import ErrorBoundary from './ErrorBoundary';
+import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';
 
 function getActiveProductFromUrl() {
   const productUrl = window.location.hostname.split('.')[0];
@@ -119,14 +120,7 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
             }}
           />
         )}
-        {showEmailVerificationBanner && (
-          <Banner
-            themeColor="orange"
-            text={bannerOptions.text}
-            actionButton={bannerOptions.actionButton}
-            dismissible={false}
-          />
-        )}
+        {showEmailVerificationBanner && <EmailVerificationBanner />}
         {!user.loading && <Modal {...modal} />}
       </ModalContext.Provider>
     </UserContext.Provider>

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -97,7 +97,6 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
 
   const showEmailVerificationBanner =
     !loading && user.shouldShowEmailVerificationCommunication;
-  const { bannerOptions } = useEmailVerification();
 
   return (
     <UserContext.Provider value={user}>

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -19,7 +19,6 @@ import { ModalContext } from '../../common/context/Modal';
 import useModal, { MODALS } from '../../common/hooks/useModal';
 import { QUERY_ACCOUNT } from '../../common/graphql/account';
 import useUserTracker from '../../common/hooks/useUserTracker';
-import useEmailVerification from '../../common/hooks/useEmailVerification';
 import getTrialBannerCopy from './getTrialBannerCopy';
 import ErrorBoundary from './ErrorBoundary';
 import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -6,7 +6,6 @@ import {
   ApolloClient,
   InMemoryCache,
   useQuery,
-  useMutation,
   HttpLink,
 } from '@apollo/client';
 import ReactDOM from 'react-dom';
@@ -18,11 +17,9 @@ import Modal from '../../components/Modal/index';
 import { UserContext } from '../../common/context/User';
 import { ModalContext } from '../../common/context/Modal';
 import useModal, { MODALS } from '../../common/hooks/useModal';
-import {
-  QUERY_ACCOUNT,
-  ACCOUNT_INITIATE_EMAIL_VERIFICATION,
-} from '../../common/graphql/account';
+import { QUERY_ACCOUNT } from '../../common/graphql/account';
 import useUserTracker from '../../common/hooks/useUserTracker';
+import useEmailVerification from '../../common/hooks/useEmailVerification';
 import getTrialBannerCopy from './getTrialBannerCopy';
 import ErrorBoundary from './ErrorBoundary';
 
@@ -97,20 +94,10 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
     }
   }
 
-  const [
-    initiateEmailVerification,
-    {
-      data: initiateEmailVerificationData,
-      error: initiateEmailVerificationError,
-    },
-  ] = useMutation(ACCOUNT_INITIATE_EMAIL_VERIFICATION);
-
-  // Email verification banner
   const showEmailVerificationBanner =
     !loading && user.shouldShowEmailVerificationCommunication;
-  const resendEmailVerificationSuccess =
-    initiateEmailVerificationData?.accountInitiateEmailVerification?.success;
-
+  const { bannerOptions } = useEmailVerification();
+  console.log(bannerOptions);
   return (
     <UserContext.Provider value={user}>
       <ModalContext.Provider value={modal}>
@@ -134,19 +121,9 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
         )}
         {showEmailVerificationBanner && (
           <Banner
-            text={
-              resendEmailVerificationSuccess
-                ? 'Please check your inbox to verify your email'
-                : 'Please verify your email address. Contact support for help.'
-            }
-            actionButton={
-              resendEmailVerificationSuccess
-                ? {}
-                : {
-                    label: 'Re-send verification email',
-                    action: () => initiateEmailVerification(),
-                  }
-            }
+            themeColor="orange"
+            text={bannerOptions.text}
+            actionButton={bannerOptions.actionButton}
             dismissible={false}
           />
         )}


### PR DESCRIPTION
### Description

This PR:

- Adds a banner for users to re-send email verifications is their account returns with `shouldShowEmailVerificationCommunication`
- Adds a `dismissible` prop for the `Banner` component to remove the ability to dismiss a banner. For example, if a user were to dismiss the email verification banner, the expected behavior is that it would prevent it from appearing again, but as soon as the page refreshes they would see it. Hiding the ability to dismiss it makes it feel like a better UX in that scenario. The default is to allow dismissing, so you need to explicitly remove it. 
- Adds a check that an action is provided, otherwise don't show a button. 

### Jira
https://buffer.atlassian.net/browse/COREP-610

### Related PRs:
https://github.com/bufferapp/core-authentication-service/pull/1566
https://github.com/bufferapp/buffer-api-gateway/pull/415