### PR TITLE
[UPDATE] Allow plan update when only quantity is changed

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -119,6 +119,8 @@ export const PlanSelectorContainer = ({
     hasPaymentDetails,
     isActiveTrial: trialInfo?.isActive,
     isAwaitingUserAction: trialInfo?.isAwaitingUserAction,
+    currentChannelQuantity: currentQuantity,
+    updatedChannelQuantity: channelsCount,
   });
   const { headerLabel } = useHeaderLabel(
     trialInfo?.isActive,
@@ -183,8 +185,12 @@ export const PlanSelectorContainer = ({
       setChannelsCounterValue
     );
 
-    updateButton(selectedPlan);
+    updateButton(selectedPlan, channelsCount);
   }, [selectedPlan]);
+
+  useEffect(() => {
+    updateButton(selectedPlan, channelsCount);
+  }, [channelsCount]);
 
   useEffect(() => {
     if (data?.billingUpdateSubscriptionPlan.success) {

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
@@ -9,8 +9,10 @@ const useButtonOptions = ({
   hasPaymentDetails,
   isActiveTrial,
   isAwaitingUserAction,
+  currentChannelQuantity,
+  updatedChannelQuantity,
 }) => {
-  const getLabel = (selectedPlan) => {
+  const getLabel = (selectedPlan, updatedQuantity) => {
     if (isActiveTrial) {
       if (selectedPlan.planId === 'free') {
         return 'Confirm Plan Change';
@@ -18,13 +20,17 @@ const useButtonOptions = ({
     } else if (selectedPlan?.isCurrentPlan) {
       if (selectedPlan.planId === 'free' && isAwaitingUserAction) {
         return 'Confirm Free Plan';
+      } else if (currentChannelQuantity !== updatedQuantity) {
+        return 'Confirm changes';
       } else return 'Stay On My Current Plan';
     } else if (hasPaymentDetails || selectedPlan.planId === 'free') {
       return 'Confirm Plan Change';
     }
     return 'Go To Payment';
   };
-  const [label, setLabel] = useState(getLabel(selectedPlan));
+  const [label, setLabel] = useState(
+    getLabel(selectedPlan, currentChannelQuantity, updatedChannelQuantity)
+  );
 
   const buttonFunction = () => {
     if (selectedPlan.isCurrentPlan && isActiveTrial && hasPaymentDetails) {
@@ -32,6 +38,13 @@ const useButtonOptions = ({
     }
 
     if (selectedPlan.planId === 'free') {
+      return updatePlan;
+    }
+
+    if (
+      selectedPlan.isCurrentPlan &&
+      currentChannelQuantity !== updatedChannelQuantity
+    ) {
       return updatePlan;
     }
 
@@ -44,8 +57,8 @@ const useButtonOptions = ({
 
   const [action, setAction] = useState(() => buttonFunction());
 
-  const updateButton = (selectedPlan) => {
-    setLabel(getLabel(selectedPlan));
+  const updateButton = (selectedPlan, channelsCount) => {
+    setLabel(getLabel(selectedPlan, channelsCount));
     setAction(() => buttonFunction());
   };
 

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
@@ -21,7 +21,7 @@ const useButtonOptions = ({
       if (selectedPlan.planId === 'free' && isAwaitingUserAction) {
         return 'Confirm Free Plan';
       } else if (currentChannelQuantity !== updatedQuantity) {
-        return 'Confirm changes';
+        return 'Confirm Changes';
       } else return 'Stay On My Current Plan';
     } else if (hasPaymentDetails || selectedPlan.planId === 'free') {
       return 'Confirm Plan Change';

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
@@ -1,5 +1,5 @@
-import useButtonOptions from './useButtonOptions';
 import { renderHook, act } from '@testing-library/react-hooks';
+import useButtonOptions from './useButtonOptions';
 
 const updatePlan = () => {
   console.log('update the plan');
@@ -181,5 +181,35 @@ describe('useButtonOptions', () => {
     });
 
     expect(result.current.label).toBe('Confirm Plan Change');
+  });
+
+  it("should update the label and action when there's a change to the channels amount", () => {
+    const selectedPlan = {
+      planId: 'team',
+      isCurrentPlan: true,
+    };
+
+    const currentChannelQuantity = 10;
+    const updatedChannelQuantity = 12;
+
+    const hasPaymentDetails = true;
+
+    const { result } = renderHook(() =>
+      useButtonOptions({
+        selectedPlan,
+        updatePlan,
+        openPaymentMethod,
+        hasPaymentDetails,
+        currentChannelQuantity,
+        updatedChannelQuantity,
+      })
+    );
+
+    act(() => {
+      result.current.updateButton(selectedPlan, 12);
+    });
+
+    expect(result.current.label).toBe('Confirm changes');
+    expect(result.current.action).toBe(updatePlan);
   });
 });

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
@@ -209,7 +209,7 @@ describe('useButtonOptions', () => {
       result.current.updateButton(selectedPlan, 12);
     });
 
-    expect(result.current.label).toBe('Confirm changes');
+    expect(result.current.label).toBe('Confirm Changes');
     expect(result.current.action).toBe(updatePlan);
   });
 });


### PR DESCRIPTION
🚢  This PR allows users to update plans with the new amount of channels but stay on the same plan.

Jira ticket: https://buffer.atlassian.net/browse/GROW-387

This includes new unit tests to cover updates to existing functions
<img width="1418" alt="Screen Shot 2022-03-02 at 2 45 31 pm" src="https://user-images.githubusercontent.com/7763710/156296737-0f16e8dd-3712-417b-b37c-8a01f75639c1.png">

