### PR TITLE
Fix/z index modals

### DIFF
--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -22,11 +22,15 @@ import TrialExpired from './modals/TrialExpired';
 import QuantityUpdate from './modals/QuantityUpdate';
 import { Paywall } from './modals/Paywall';
 
-import { shouldShowFreeUserStartTrialPrompt, shouldShowChannelConnectionPrompt, shouldShowPaywallModal } from './utils';
+import {
+  shouldShowFreeUserStartTrialPrompt,
+  shouldShowChannelConnectionPrompt,
+  shouldShowPaywallModal,
+} from './utils';
 
 const ModalWrapper = styled.div`
   > div {
-    z-index: 1;
+    z-index: 2;
   }
 `;
 
@@ -183,7 +187,9 @@ const Modal = React.memo(({ modal, openModal }) => {
   return (
     <>
       {hasModal && (
-        <ModalWrapper><ModalContent modal={modal} closeAction={() => openModal(null)} /></ModalWrapper>
+        <ModalWrapper>
+          <ModalContent modal={modal} closeAction={() => openModal(null)} />
+        </ModalWrapper>
       )}
     </>
   );

--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -29,8 +29,10 @@ import {
 } from './utils';
 
 const ModalWrapper = styled.div`
+  min-height: 500px;
+
   > div {
-    z-index: 2;
+    z-index: 1;
   }
 `;
 


### PR DESCRIPTION
Link to bug reported on prod: https://buffer.slack.com/archives/C0DLE125Q/p1646170700283989

The navigator has recently been forced on top of everything for upcoming work to do with paywall and nondismissable modals. 

To fix this for now we have added a min height to the ModalWrapper so users on a smaller screen can scroll the nav bar away.

**Testing notes:**
Tested on a few different small screen sizes and I seem to be able to scroll the nav bar away.
@hamstu did you want to test against the scenario you originally encountered with? If not I'll merge this in tomorrow 😊


<img width="1348" alt="Screen Shot 2022-03-07 at 4 44 55 pm" src="https://user-images.githubusercontent.com/7763710/156982056-41a6ee65-3670-4ae6-9868-193d39c4bf21.png">
<img width="1352" alt="Screen Shot 2022-03-07 at 4 44 46 pm" src="https://user-images.githubusercontent.com/7763710/156982078-874c7e86-5a1c-4a4c-9544-29335f2b74ed.png">
 