### PR TITLE
[GROW-405] Update Confirm Trial Plan to Confirm Plan to be less confusing

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.js
@@ -16,7 +16,7 @@ const useButtonOptions = ({
     if (isActiveTrial) {
       if (selectedPlan.planId === 'free') {
         return 'Confirm Plan Change';
-      } else return hasPaymentDetails ? 'Confirm Trial Plan' : 'Go To Payment';
+      } else return hasPaymentDetails ? 'Confirm Plan' : 'Go To Payment';
     } else if (selectedPlan?.isCurrentPlan) {
       if (selectedPlan.planId === 'free' && isAwaitingUserAction) {
         return 'Confirm Free Plan';

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useButtonOptions.test.jsx
@@ -84,7 +84,7 @@ describe('useButtonOptions', () => {
     expect(result.current.label).toBe('Confirm Plan Change');
     expect(result.current.action).toBe(updatePlan);
   });
-  it("should return {label 'Confirm Trial Plan', action: updatePlan} is on a trial and has payment details", () => {
+  it("should return {label 'Confirm Plan', action: updatePlan} is on a trial and has payment details", () => {
     const selectedPlan = {
       planId: 'team',
       planInterval: 'year',
@@ -104,7 +104,7 @@ describe('useButtonOptions', () => {
       })
     );
 
-    expect(result.current.label).toBe('Confirm Trial Plan');
+    expect(result.current.label).toBe('Confirm Plan');
     expect(result.current.action).toBe(updatePlan);
   });
   it("should return {label 'Go To Payment', action: openPaymentMethod} is on a trial and doesn't have payment details", () => {

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.js
@@ -1,8 +1,6 @@
 import { freePlan } from '../../../../../common/mocks/freePlan';
 
 const useHeaderLabel = (isActiveTrial, planOptions, isFreePlan) => {
-  let headerLabel;
-
   if (isActiveTrial) {
     return { headerLabel: 'Confirm Plan' };
   }

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.js
@@ -4,7 +4,7 @@ const useHeaderLabel = (isActiveTrial, planOptions, isFreePlan) => {
   let headerLabel;
 
   if (isActiveTrial) {
-    return { headerLabel: 'Confirm Trial Plan' };
+    return { headerLabel: 'Confirm Plan' };
   }
 
   const currentPlan = isFreePlan

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.test.jsx
@@ -2,11 +2,11 @@ import useHeaderLabel from './useHeaderLabel';
 import { renderHook } from '@testing-library/react-hooks';
 
 describe('useHeaderLabel', () => {
-  it("should set the header label to 'Confirm Trial Plan' when a user is on a trial", () => {
+  it("should set the header label to 'Confirm Plan' when a user is on a trial", () => {
     const isActiveTrial = true;
     const { result } = renderHook(() => useHeaderLabel(isActiveTrial));
 
-    expect(result.current.headerLabel).toBe('Confirm Trial Plan');
+    expect(result.current.headerLabel).toBe('Confirm Plan');
   });
   it("should set the header label to 'Change my plan' when a user changes plan", () => {
     const isActiveTrial = false;

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useHeaderLabel.test.jsx
@@ -1,5 +1,5 @@
-import useHeaderLabel from './useHeaderLabel';
 import { renderHook } from '@testing-library/react-hooks';
+import useHeaderLabel from './useHeaderLabel';
 
 describe('useHeaderLabel', () => {
   it("should set the header label to 'Confirm Plan' when a user is on a trial", () => {


### PR DESCRIPTION
Updating some copy and a CTA to be less confusing from `Confirm Trial Plan` to `Confirm Plan`.

<img width="1220" alt="Screenshot 2022-03-07 at 16 38 09" src="https://user-images.githubusercontent.com/1514227/157066221-4000c6c8-1709-453b-9c00-b1bd9b3a60ca.png">
