### PR TITLE
Update e-mail verification banner copy to provide more clarity for users

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,5 @@
   "video": false,
   "viewportWidth": 1440,
   "viewportHeight": 900,
-  "pluginsFile": "./cypress.plugins.js",
-  "defaultCommandTimeout": 6000
+  "pluginsFile": "./cypress.plugins.js"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "video": false,
   "viewportWidth": 1440,
   "viewportHeight": 900,
-  "pluginsFile": "./cypress.plugins.js"
+  "pluginsFile": "./cypress.plugins.js",
+  "defaultCommandTimeout": 6000
 }

--- a/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
+++ b/packages/app-shell/src/exports/Navigator/components/EmailVerificationBanner/EmailVerificationBanner.jsx
@@ -19,7 +19,8 @@ const EmailVerificationBanner = () => {
         customHTML={
           <>
             <Text type="paragraph" color="#fff">
-              Please verify your email address. You can visit our{' '}
+              <strong>Verify your email:</strong> An email has been sent to your
+              inbox to verify your email address. You can visit our{' '}
               <a
                 href="https://support.buffer.com/hc/en-us/articles/4563021461907-Verifying-your-Buffer-email-address"
                 target="_blank"


### PR DESCRIPTION
Updates the email verification banner copy for better UX:

<img width="1959" alt="CleanShot 2022-03-07 at 10 27 03@2x" src="https://user-images.githubusercontent.com/10112294/157064798-18da101c-6747-4a96-a533-503ec801488f.png">


Related Slack thread: https://buffer.slack.com/archives/C6JL89JG6/p1646660985383169?thread_ts=1646655318.471679&cid=C6JL89JG6