### PR TITLE
[UPDATE] add missing value to mock accont

### DIFF
--- a/cypress/fixtures/accountObFreeUpgrade.json
+++ b/cypress/fixtures/accountObFreeUpgrade.json
@@ -11,6 +11,7 @@
             "geid1_free_user_trial_prompt"
          ],
          "isImpersonation":false,
+         "shouldShowEmailVerificationCommunication": true,
          "currentOrganization":{
             "id":"606b65d6dad38c03d2b70793",
             "name":"test",


### PR DESCRIPTION
This fixes a failing cypress test. 
Message posted about issue here: https://buffer.slack.com/archives/C0DLE125Q/p1646669562408999

The fix required added a missing value to the mock user account for the cypress test.