### PR TITLE
[FIX] Typo in billing text

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.jsx
@@ -51,11 +51,10 @@ function UpdatedPlanInfo(props) {
         </Row>
       </Section>
       <CurrentPaymentContainer>
-        New monthly cost:{' '}
-        <span>{getProductPriceCycleText(newPrice, planCycle)}</span>
+        New cost: <span>{getProductPriceCycleText(newPrice, planCycle)}</span>
       </CurrentPaymentContainer>
       <CancellationInfo>
-        This will be billed every month until canceled.
+        This will be billed every {planCycle} until canceled.
       </CancellationInfo>
     </UpdatedPlanInfoContainer>
   );


### PR DESCRIPTION
🚢  Fix wording in updated billing section to match with selected plan cycle

<img width="1271" alt="Screen Shot 2022-03-09 at 10 39 11 am" src="https://user-images.githubusercontent.com/7763710/157350265-6549bddf-64c2-4525-a0cc-00cae128c994.png">
<img width="1271" alt="Screen Shot 2022-03-09 at 10 39 17 am" src="https://user-images.githubusercontent.com/7763710/157350278-5f8fa7ff-9be4-41b9-b358-a808ab84e715.png">

