### PR TITLE
Task/grow 408 default selected plan

### DIFF
--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -70,12 +70,11 @@ export function getCurrentPlanFromPlanOptions(planOptions) {
   return planOptions.find((plan) => plan.isCurrentPlan);
 }
 
-export function getDefaultSelectedPlan(planOptions, isUpgradeIntent) {
+export function getDefaultSelectedPlan(planOptions) {
   const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
   const essentialsPlan = getPlanByPlanId('essentials', planOptions);
 
-  const defaultSelectedPlan =
-    isUpgradeIntent || !currentPlan ? essentialsPlan : currentPlan;
+  const defaultSelectedPlan = !currentPlan ? essentialsPlan : currentPlan;
 
   return defaultSelectedPlan;
 }

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -205,36 +205,10 @@ describe('Modal - utils', () => {
       });
     });
 
-    it('should set the default selected plan to the current plan when isUpgradeIntent is false AND there is a current plan found', () => {
-      const planOptions = [
-        { planId: 'free', planInterval: 'month', isCurrentPlan: false },
-        ...listOfFilteredPlanOptions,
-      ];
-
-      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
-
-      expect(result).toEqual({
-        planId: 'team',
-        planInterval: 'year',
-        isCurrentPlan: true,
-      });
-    });
-
     it('should set the default selected plan to essentials when isCurrentPlan cannot be found in the list of plans', () => {
       const planOptions = [...listOfPlanOptionsWithNoCurrentPlan];
 
       const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
-
-      expect(result).toEqual({
-        planId: 'essentials',
-        planInterval: 'month',
-        isCurrentPlan: false,
-      });
-    });
-
-    it('should set the default selected plan to essentials when isUpgradeIntent ', () => {
-      const planOptions = [...listOfFilteredPlanOptions];
-      const result = getDefaultSelectedPlan(planOptions, true);
 
       expect(result).toEqual({
         planId: 'essentials',

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -26,7 +26,7 @@ const ModalTesting = () => {
           actions.openModal(MODALS.planSelector, {
             cta: 'renderModal',
             ctaButton: 'renderModal',
-            isUpgradeIntent: true,
+            isUpgradeIntent: false,
           });
         }}
       >

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -26,7 +26,7 @@ const ModalTesting = () => {
           actions.openModal(MODALS.planSelector, {
             cta: 'renderModal',
             ctaButton: 'renderModal',
-            isUpgradeIntent: false,
+            isUpgradeIntent: true,
           });
         }}
       >


### PR DESCRIPTION
Jira ticket: https://buffer.atlassian.net/browse/GROW-408

This fixes the issue where the essentials plan was getting set as the default plan whenever upgradeIntent was true