### PR TITLE
[GROW-411] Emits a modal event on success modal

### DIFF
--- a/packages/app-shell/src/common/hooks/useModal.js
+++ b/packages/app-shell/src/common/hooks/useModal.js
@@ -53,6 +53,13 @@ function useModal() {
     }
   }, []);
 
+  useEffect(() => {
+    if (modal === MODALS.success) {
+      // propagate a modal event on success
+      ACTIONS.openModal(modal)
+    }
+  }, [modal])
+
   // Open modal from events
   function handleOpenModal({ detail }) {
     const { modal: modalKey, data: modalData } = detail;

--- a/packages/app-shell/src/components/Modal/modals/Confirmation/getCopy.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Confirmation/getCopy.jsx
@@ -3,7 +3,7 @@ import Text from '@bufferapp/ui/Text';
 import Link from '@bufferapp/ui/Link';
 
 export const SUCCESS_CTA = "Great, Let's Go!";
-const getCopy = ({ planName, startedTrial }) => {
+const getCopy = ({ planName, startedTrial, stayedOnSamePlan }) => {
   if (startedTrial) {
     return {
       label: 'Trial activated! Time to explore.',
@@ -24,7 +24,7 @@ const getCopy = ({ planName, startedTrial }) => {
     };
   } 
   
-  if (planName) {
+  if (planName && !stayedOnSamePlan) {
     return {
       label: `Congrats! Welcome to the ${planName} plan`,
       description: `You've successfully saved your payment details! Start using your ${planName} plan features.`,

--- a/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
@@ -54,12 +54,14 @@ const Screen = ({
   onlyUpdatedCardDetails,
   startedTrial,
   closeModal,
+  stayedOnSamePlan
 }) => {
   const planName = selectedPlan ? selectedPlan.planName : null;
   const { label, description, buttonCopy, imageUrl, footer } = getCopy({
     planName,
     onlyUpdatedCardDetails,
     startedTrial,
+    stayedOnSamePlan
   });
 
   const currentUser = useContext(UserContext);
@@ -106,6 +108,7 @@ const Confirmation = () => {
               selectedPlan={data.selectedPlan}
               onlyUpdatedCardDetails={data.onlyUpdatedCardDetails}
               startedTrial={data.startedTrial}
+              stayedOnSamePlan={data.stayedOnSamePlan}
               closeModal={() => {
                 openModal(null);
               }}

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/index.jsx
@@ -39,11 +39,7 @@ const PlanSelector = () => {
                   'free'
                 }
                 openSuccess={(newData) => {
-                  if (newData.stayedOnSamePlan && newData.splitSBBEnabled) {
-                    return modal.openModal(null);
-                  }
-
-                  return modal.openModal(MODALS.success, newData);
+                  modal.openModal(MODALS.success, newData);
                 }}
                 isUpgradeIntent={modal.data?.isUpgradeIntent}
               />


### PR DESCRIPTION
This piece of code is listening to a modal change within the navigator and emits an event with this modal (`ACTIONS.openModal` runs the event dispatcher). 
This event can be listened to by the different products and refresh the organization data and therefore the organization information on the various pages.
Essentially, this will be triggered when we successfully have updated a plan and on the account app, if we listen to and act to this event, we can update the Billing and the Channels page, without a hard refresh. 

@gisete I believe that we could reuse this (or a similar) approach for the quantity modal as well. 

@daisymarie128 I changed the part where we update only the quantity and the plan remains the same. The reason was that I was becoming a bit tricky to trigger a success event for the other apps when we were opening the modal with `null`. Instead, I changed the confirmation "Success" modal to display an unused screen that we have and displays that the Billing details has been updated. 

<img width="795" alt="Screen Shot 2022-03-10 at 13 05 27" src="https://user-images.githubusercontent.com/1632257/157660145-c95ce433-d5bc-4510-bd0e-7655e15def43.png">
