### PR TITLE
Task/grow 420 agency channel restriction

### DIFF
--- a/packages/app-shell/src/common/components/Channels/Channels.jsx
+++ b/packages/app-shell/src/common/components/Channels/Channels.jsx
@@ -29,7 +29,7 @@ function Channels(props) {
   return (
     <ChannelsContainer>
       <Title>
-        <span>Channels:</span>
+        <span>Channels</span>
         <Icons>
           <InstagramIcon size="medium" />
           <FacebookIcon size="medium" />

--- a/packages/app-shell/src/common/components/Channels/Channels.style.js
+++ b/packages/app-shell/src/common/components/Channels/Channels.style.js
@@ -1,25 +1,21 @@
 import styled from 'styled-components';
-import { grayLight } from '@bufferapp/ui/style/colors';
+import { grayDark } from '@bufferapp/ui/style/colors';
 import { fontSizeSmall } from '@bufferapp/ui/style/fonts';
 
 export const ChannelsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding-bottom: 20px;
 
   font-size: ${fontSizeSmall};
-  border-bottom: 1px ${grayLight} solid;
 `;
 
 export const Title = styled.div`
   display: flex;
   flex-direction: row;
+  min-width: 160px;
   width: 100%;
   margin-bottom: 20px;
-
-  span {
-    margin-right: 15px;
-  }
+  justify-content: space-between;
 `;
 
 export const Icons = styled.div`
@@ -31,6 +27,7 @@ export const Icons = styled.div`
     width: 12px;
     height: 12px;
     margin-right: 6px;
+    color: ${grayDark};
 
     &:last-of-type {
       margin-right: 0;

--- a/packages/app-shell/src/common/utils/user.js
+++ b/packages/app-shell/src/common/utils/user.js
@@ -20,3 +20,11 @@ export function isOnAgencyTrial(user) {
 
   return false;
 }
+
+export function getUsersCurrentPlan(user) {
+  return user.currentOrganization.billing.subscription.plan;
+}
+
+export function getUsersCurrentChannelSlotDetails(user) {
+  return user.currentOrganization.billing.channelSlotDetails;
+}

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -47,7 +47,6 @@ import {
 import {
   filterListOfPlans,
   handleChannelsCountConditions,
-  getCurrentPlanFromPlanOptions,
   calculateTotalSlotsPrice,
   handleUpgradeIntent,
 } from '../../../utils';

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -40,6 +40,8 @@ import AgencyPlanSection from './AgencyPlanSection';
 import {
   isAgencyUser,
   isOnAgencyTrial,
+  getUsersCurrentPlan,
+  getUsersCurrentChannelSlotDetails,
 } from '../../../../../common/utils/user';
 
 import {
@@ -78,10 +80,10 @@ export const PlanSelectorContainer = ({
     isUpgradeIntent
   );
 
-  const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
+  const currentPlan = getUsersCurrentPlan(user);
   const currentPlanId = currentPlan.planId;
 
-  const { currentQuantity } = currentPlan.channelSlotDetails;
+  const { currentQuantity } = getUsersCurrentChannelSlotDetails(user);
   const {
     flatFee: selectedPlanFlatFee,
     pricePerQuantity: selectedPlanPricePerQuantity,
@@ -293,6 +295,7 @@ export const PlanSelectorContainer = ({
           decreaseCounter={() => decreaseCounter()}
           newPrice={newPrice}
           channelCounterMessageStatus={channelCountMessageStatus}
+          currentChannelQuantity={currentQuantity}
         />
         <ButtonContainer>
           <Button

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -1,28 +1,23 @@
 import React, { useState, useEffect } from 'react';
 
 import { Text, Button } from '@bufferapp/ui';
-import InstagramIcon from '@bufferapp/ui/Icon/Icons/Instagram';
-import FacebookIcon from '@bufferapp/ui/Icon/Icons/Facebook';
-import LinkedInIcon from '@bufferapp/ui/Icon/Icons/LinkedIn';
-import PinterestIcon from '@bufferapp/ui/Icon/Icons/Pinterest';
-import ShopifyIcon from '@bufferapp/ui/Icon/Icons/Shopify';
-import TwitterIcon from '@bufferapp/ui/Icon/Icons/Twitter';
 
 import { MODALS } from '../../../../../common/hooks/useModal';
-import ChannelCounter from '../../../../../common/components/Counter/Counter';
 import useChannelsCounter from '../../../../../common/hooks/useChannelsCounter';
 import { getProductPriceCycleText } from '../../../../../common/utils/product';
-import { calculateTotalSlotsPrice } from '../../../utils';
+import Channels from '../../../../../common/components/Channels/Channels';
+import {
+  calculateTotalSlotsPrice,
+  handleChannelsCountConditions,
+} from '../../../utils';
 
 import {
   Header,
   SectionContainer,
   Section,
-  Icons,
-  Title,
   ButtonWrapper,
   InnerContainer,
-  ChannelCounterWrapper,
+  ChannelsWrapper,
   Summary,
 } from './style';
 
@@ -38,13 +33,13 @@ const CardBody = ({
   openModal,
 }) => {
   const [hasCounterChanged, changeCounterState] = useState(false);
-
   const {
     channelsCount,
-    // setChannelsCounterValue,
+    setChannelsCounterValue,
     increaseCounter,
     decreaseCounter,
-  } = useChannelsCounter(quantity, minimumQuantity);
+    channelCountMessageStatus,
+  } = useChannelsCounter(planId, quantity, minimumQuantity);
 
   const newPrice = calculateTotalSlotsPrice(
     planId,
@@ -61,6 +56,14 @@ const CardBody = ({
       changeCounterState(true);
     }
   });
+
+  useEffect(() => {
+    handleChannelsCountConditions(
+      planId,
+      channelsCount,
+      setChannelsCounterValue
+    );
+  }, [channelsCount]);
 
   return (
     <>
@@ -85,26 +88,14 @@ const CardBody = ({
       <SectionContainer>
         <Section>
           <InnerContainer>
-            <div>
-              <Title>
-                <Text>Channels </Text>
-                <Icons>
-                  <InstagramIcon size="medium" />
-                  <FacebookIcon size="medium" />
-                  <TwitterIcon size="medium" />
-                  <PinterestIcon size="medium" />
-                  <LinkedInIcon size="medium" />
-                  <ShopifyIcon size="medium" />
-                </Icons>
-              </Title>
-              <ChannelCounterWrapper>
-                <ChannelCounter
-                  channelsCount={channelsCount}
-                  onDecreaseCounter={() => decreaseCounter()}
-                  onIncreaseCounter={() => increaseCounter()}
-                />
-              </ChannelCounterWrapper>
-            </div>
+            <ChannelsWrapper>
+              <Channels
+                channelsCount={channelsCount}
+                onIncreaseCounter={() => increaseCounter()}
+                onDecreaseCounter={() => decreaseCounter()}
+                channelCounterMessageStatus={channelCountMessageStatus}
+              />
+            </ChannelsWrapper>
 
             <Summary>
               {hasCounterChanged ? (

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/style.js
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/style.js
@@ -25,35 +25,8 @@ export const Header = styled.div`
   }
 `;
 
-export const Title = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  margin-bottom: 20px;
-
-  span {
-    margin-right: 8px;
-  }
-
-  svg {
-    color: ${grayDark};
-  }
-`;
-
-export const Icons = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  svg {
-    width: 12px;
-    height: 12px;
-    margin-right: 6px;
-
-    &:last-of-type {
-      margin-right: 0;
-    }
-  }
+export const ChannelsWrapper = styled.div`
+  flex-basis: 33%;
 `;
 
 export const SectionContainer = styled.div`
@@ -78,15 +51,12 @@ export const InnerContainer = styled.div`
   font-size: ${fontSizeSmall};
 `;
 
-export const ChannelCounterWrapper = styled.div`
-  width: 140px;
-`;
-
 export const Summary = styled.div`
   display: flex;
   flex-direction: column;
   align-items: end;
   flex: 1;
+  flex-basis: 66%;
 
   p {
     color: ${grayDark};

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/index.jsx
@@ -31,6 +31,7 @@ const QuantityUpdate = () => {
 
             const { name: planName, id: planId } =
               user.currentOrganization.billing.subscription.plan;
+
             const planOptions =
               user.currentOrganization.billing.changePlanOptions;
             const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
@@ -45,7 +46,7 @@ const QuantityUpdate = () => {
                   channelFee={flatFee}
                   pricePerQuantity={pricePerQuantity}
                   minimumQuantity={minimumQuantity}
-                  plandId={planId}
+                  planId={planId}
                   openModal={openModal}
                 />
               </Container>

--- a/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.style.js
+++ b/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.style.js
@@ -32,8 +32,10 @@ export const Row = styled.div`
 
 export const Section = styled.div`
   display: flex;
+  margin-top: 15px;
   padding: 15px 0;
   border-bottom: 1px ${grayLight} solid;
+  border-top: 1px ${grayLight} solid;
   flex-direction: column;
 `;
 

--- a/packages/app-shell/src/components/Modal/modals/Summary/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Summary/index.jsx
@@ -43,13 +43,13 @@ function renderSBBSummary(
   increaseCounter,
   decreaseCounter,
   newPrice,
-  channelCounterMessageStatus
+  channelCounterMessageStatus,
+  currentChannelQuantity
 ) {
   const {
     planName: currentPlanName,
     totalPrice: currentPlanPricing,
     planInterval: currentPlanInterval,
-    channelsQuantity: currentChannelsQuantity,
     summary: currentPlanSummary,
   } = currentPlan;
   const currentPlanUsersText = findPlanUserDetails(currentPlanSummary.details);
@@ -66,7 +66,7 @@ function renderSBBSummary(
         planName={currentPlanName}
         planPrice={currentPlanPricing}
         planCycle={currentPlanInterval}
-        numberOfChannels={currentChannelsQuantity}
+        numberOfChannels={currentChannelQuantity}
         numberOfUsers={currentPlanUsersText}
       />
       <UpdatedPlanInfo
@@ -94,6 +94,7 @@ const Summary = ({
   decreaseCounter,
   newPrice,
   channelCounterMessageStatus,
+  currentChannelQuantity,
 }) => {
   const currentPlan = planOptions.find((option) => option.isCurrentPlan);
   const currentPlanId = currentPlan.planId;
@@ -179,7 +180,8 @@ const Summary = ({
             increaseCounter,
             decreaseCounter,
             newPrice,
-            channelCounterMessageStatus
+            channelCounterMessageStatus,
+            currentChannelQuantity
           )
         ) : (
           <>
@@ -230,6 +232,7 @@ const SummaryProvider = ({
   decreaseCounter,
   newPrice,
   channelCounterMessageStatus,
+  currentChannelQuantity,
 }) => {
   return (
     <UserContext.Consumer>
@@ -249,6 +252,7 @@ const SummaryProvider = ({
             decreaseCounter={() => decreaseCounter()}
             newPrice={newPrice}
             channelCounterMessageStatus={channelCounterMessageStatus}
+            currentChannelQuantity={currentChannelQuantity}
           />
         );
       }}


### PR DESCRIPTION
This PR adds the functionality to restrict users from selecting less than 10 channels for the agency plan in the new QuantityUpdate modal.

This PR also includes:
- Refactors `Channels` component so it can be reused in different places.
- Fix to plan selector showing the wrong current quantity of channels.
<img width="587" alt="Screen Shot 2022-03-14 at 2 36 23 pm" src="https://user-images.githubusercontent.com/7763710/158105723-9d35b45a-cd86-4e08-986f-634395f326ff.png">

<img width="630" alt="Screen Shot 2022-03-14 at 2 36 44 pm" src="https://user-images.githubusercontent.com/7763710/158105716-d601a6a8-0340-4287-a0a9-11a6e30cfaad.png">

