### PR TITLE
[GROW-423] update copy

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -110,7 +110,7 @@ const CardBody = ({
               {hasCounterChanged ? (
                 <>
                   <Text type="p">
-                    New monthly cost: <strong>${newPrice}</strong>
+                    New cost: <strong>${newPrice}</strong>
                   </Text>
                   <Text>
                     This will be billed every {planCycle} until canceled


### PR DESCRIPTION
Updating `New monthly cost` to `New cost`
The description below already have the information: `planCycle` can be either `month` or `year`
https://github.com/bufferapp/app-shell/blob/d552c43d83a99a697d47a9aacfea0faa086b6cb5/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx#L116
<img width="512" alt="image" src="https://user-images.githubusercontent.com/1514227/158151538-d9752686-835e-4811-822a-a15abbe5a4f2.png">
