### PR TITLE
[GROW - 422] Disable submit button if # in counter hasn't changed

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -37,7 +37,7 @@ const CardBody = ({
   planCycle,
   openModal,
 }) => {
-  const [hasCounterChanged, changeCounterState] = useState(false);
+  const [hasCounterChanged, updateCounter] = useState(false);
 
   const {
     channelsCount,
@@ -55,12 +55,9 @@ const CardBody = ({
   );
 
   useEffect(() => {
-    changeCounterState(false);
-
-    if (channelsCount !== quantity) {
-      changeCounterState(true);
-    }
-  });
+    // available channels is different from # in counter
+    updateCounter(channelsCount !== quantity);
+  }, [channelsCount]);
 
   return (
     <>
@@ -134,6 +131,7 @@ const CardBody = ({
             openModal(MODALS.paymentMethod, data);
           }}
           label="Confirm and Pay"
+          disabled={!hasCounterChanged}
         />
       </ButtonWrapper>
     </>


### PR DESCRIPTION
Disabled "Confirm and Pay" submit button if number of channels in the counter is the same as the number of channels the customer already has.

Also cleaned up the code a bit.

![image](https://user-images.githubusercontent.com/10730651/158272261-3b7b4c98-c86b-4096-b680-748a17b59ac0.png)
