### PR TITLE
[GROW-428] use totalPrice instead of basePrice for description

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/index.jsx
@@ -35,7 +35,7 @@ const QuantityUpdate = () => {
             const planOptions =
               user.currentOrganization.billing.changePlanOptions;
             const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
-            const { basePrice: planPricing, planInterval } = currentPlan;
+            const { totalPrice: planPricing, planInterval } = currentPlan;
             return (
               <Container>
                 <CardBody


### PR DESCRIPTION
`planPrice` is only used in the description
https://github.com/bufferapp/app-shell/blob/4b48ab7df08617be2ef27a11e06664cab71e7ca6/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx#L72-L77

Before
<img width="520" alt="Screenshot 2022-03-15 at 11 19 17" src="https://user-images.githubusercontent.com/1514227/158357125-98613c10-edb9-49db-a2e0-dbdcf225d198.png">

After
<img width="516" alt="Screenshot 2022-03-15 at 11 18 44" src="https://user-images.githubusercontent.com/1514227/158357139-e0036481-ac9c-4e97-b06f-d1bc3a6dbb23.png">

