### PR TITLE
[UPDATE] Adjust sizing for stayed on same plan and original

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
@@ -1,5 +1,7 @@
 import React, { useContext, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
 import Text from '@bufferapp/ui/Text';
 import Button from '@bufferapp/ui/Button';
 import { black } from '@bufferapp/ui/style/colors';
@@ -12,14 +14,15 @@ import getCopy from './getCopy';
 const ScreenContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 800px;
-  height: ${({ planId }) => (planId === 'team' ? '446px' : '376px')};
+  width: ${({ stayedOnSamePlan }) => (stayedOnSamePlan ? '650px' : '800px')};
+  height: ${({ stayedOnSamePlan }) => (stayedOnSamePlan ? '290px' : '376px')};
   box-sizing: border-box;
   background-repeat: no-repeat;
   background-position-x: right;
   background-position-y: bottom;
   background-image: url(${(props) => props.imageUrl});
-  background-size: 445px;
+  background-size: ${({ stayedOnSamePlan }) =>
+    stayedOnSamePlan ? '376px' : '445px'};
   padding: 24px;
 
   p,
@@ -29,13 +32,13 @@ const ScreenContainer = styled.div`
 
   h1 {
     max-width: 324px;
-    margin-top: 22px;
-    margin-bottom: 22px;
+    margin-top: 20px;
+    margin-bottom: 20px;
   }
 
   p {
     margin-top: 0px;
-    max-width: 282px;
+    max-width: 285px;
   }
 
   p:last-child {
@@ -45,8 +48,8 @@ const ScreenContainer = styled.div`
 
 const ButtonContainer = styled.div`
   width: fit-content;
-  margin-top: 32px;
-  margin-bottom: 32px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 `;
 
 const Screen = ({
@@ -80,7 +83,7 @@ const Screen = ({
   }, []);
 
   return (
-    <ScreenContainer planId={selectedPlan.planId} imageUrl={imageUrl}>
+    <ScreenContainer stayedOnSamePlan={stayedOnSamePlan} imageUrl={imageUrl}>
       <Text type="h1">{label}</Text>
       <Text type="p">{description}</Text>
       <ButtonContainer>
@@ -95,6 +98,22 @@ const Screen = ({
       {footer && footer}
     </ScreenContainer>
   );
+};
+
+Screen.propTypes = {
+  selectedPlan: PropTypes.shape({
+    planId: PropTypes.string,
+  }).isRequired,
+  onlyUpdatedCardDetails: PropTypes.bool,
+  startedTrial: PropTypes.bool,
+  closeModal: PropTypes.func.isRequired,
+  stayedOnSamePlan: PropTypes.bool,
+};
+
+Screen.defaultProps = {
+  onlyUpdatedCardDetails: false,
+  startedTrial: false,
+  stayedOnSamePlan: false,
 };
 
 const Confirmation = () => {


### PR DESCRIPTION
🚢  [GROW-435](https://buffer.atlassian.net/browse/GROW-435)

This pr adjusts the sizing of the success modal.

There are 2 states for this modal now:
1. User changed plans - they see congratulations on changing to you new plan etc (larger messaging - what we originally had before SBB)
2. Success modal for when a user stays on the same plan but only updates channel quantity - this messaging is far shorter and looked funny with the large modal size

After this change, I have adjusted some of the CSS to make the modal look cleaner and add a conditional for the 2 states to make the sizing different for both.

Includes adding proptypes to component

<img width="1271" alt="Screen Shot 2022-03-17 at 1 08 18 pm" src="https://user-images.githubusercontent.com/7763710/158729887-9e09ca9f-3a66-4601-83c5-4311cccc44e5.png">
<img width="1272" alt="Screen Shot 2022-03-17 at 1 09 18 pm" src="https://user-images.githubusercontent.com/7763710/158730183-2cd32977-82a3-47f3-a719-15e0051d3e47.png">

<img width="1272" alt="Screen Shot 2022-03-17 at 1 09 18 pm" src="https://user-images.githubusercontent.com/7763710/158729923-83ae4111-b7ee-4843-8a35-f296d5201166.png">
<img width="1270" alt="Screen Shot 2022-03-17 at 1 09 41 pm" src="https://user-images.githubusercontent.com/7763710/158729931-c7917130-beb7-4250-8073-29d9b9f091cf.png">
<img width="1270" alt="Screen Shot 2022-03-17 at 1 10 00 pm" src="https://user-images.githubusercontent.com/7763710/158729937-519d35bf-027d-4946-9980-7e76ae142062.png">
