### PR TITLE
fix: use AccountOrganizationFiels fragment to prevent missing props

### DIFF
--- a/cypress/fixtures/accountObEssential.json
+++ b/cypress/fixtures/accountObEssential.json
@@ -4,7 +4,11 @@
       "id": "606b65d6dad38c9d20b70792",
       "email": "ob_essential@buffer.com",
       "createdAt": "2021-04-05T19:32:38.841Z",
-      "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
+      "featureFlips": [
+        "grantAnalyzeAccess",
+        "sharedChannels",
+        "engageRollOut"
+      ],
       "isImpersonation": false,
       "shouldShowEmailVerificationCommunication": true,
       "currentOrganization": {
@@ -31,6 +35,9 @@
         "channels": [
           {
             "id": "606b65e1dd934f70840bfef7",
+            "name": "testing public",
+            "service": "facebook",
+            "organizationId": "606b65d6dad38c03d2b70793",
             "__typename": "Channel"
           }
         ],
@@ -73,7 +80,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": false,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -189,7 +199,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": false,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -308,6 +321,7 @@
           "id": "606b65d6dad38c03d2b70793",
           "name": "test",
           "canEdit": true,
+          "canManageBilling": true,
           "role": "admin",
           "canMigrateToOneBuffer": {
             "canMigrate": false,
@@ -372,7 +386,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": false,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,
@@ -488,7 +505,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": false,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,

--- a/cypress/fixtures/accountObEssentialNoChannels.json
+++ b/cypress/fixtures/accountObEssentialNoChannels.json
@@ -74,7 +74,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -190,7 +193,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -309,6 +315,7 @@
           "id": "606b65d6dad38c03d2b70793",
           "name": "test",
           "canEdit": true,
+          "canManageBilling": true,
           "role": "admin",
           "canMigrateToOneBuffer": {
             "canMigrate": false,
@@ -365,7 +372,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,
@@ -481,7 +491,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,

--- a/cypress/fixtures/accountObFree.json
+++ b/cypress/fixtures/accountObFree.json
@@ -37,6 +37,9 @@
         "channels": [
           {
             "id": "606b65e1dd934f70840bfef7",
+            "name": "testing public",
+            "service": "facebook",
+            "organizationId": "606b65d6dad38c03d2b70793",
             "__typename": "Channel"
           }
         ],
@@ -79,7 +82,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -195,7 +201,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -314,6 +323,7 @@
           "id": "606b65d6dad38c03d2b70793",
           "name": "test",
           "canEdit": true,
+          "canManageBilling": true,
           "role": "admin",
           "canMigrateToOneBuffer": {
             "canMigrate": false,
@@ -378,7 +388,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,
@@ -494,7 +507,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,

--- a/cypress/fixtures/accountObFreeUpgrade.json
+++ b/cypress/fixtures/accountObFreeUpgrade.json
@@ -37,6 +37,9 @@
         "channels": [
           {
             "id": "606b65e1dd934f70840bfef7",
+            "name": "testing public",
+            "service": "facebook",
+            "organizationId": "606b65d6dad38c03d2b70793",
             "__typename": "Channel"
           }
         ],
@@ -86,7 +89,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -202,7 +208,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": true,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -321,6 +330,7 @@
           "id": "606b65d6dad38c03d2b70793",
           "name": "test",
           "canEdit": true,
+          "canManageBilling": true,
           "role": "admin",
           "canMigrateToOneBuffer": {
             "canMigrate": false,
@@ -385,7 +395,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,
@@ -501,7 +514,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": true,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,

--- a/cypress/fixtures/accountObTeam.json
+++ b/cypress/fixtures/accountObTeam.json
@@ -4,7 +4,11 @@
       "id": "606b65d6dad38c9d20b70792",
       "email": "federico+obfree@buffer.com",
       "createdAt": "2021-04-05T19:32:38.841Z",
-      "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
+      "featureFlips": [
+        "grantAnalyzeAccess",
+        "sharedChannels",
+        "engageRollOut"
+      ],
       "isImpersonation": false,
       "shouldShowEmailVerificationCommunication": true,
       "currentOrganization": {
@@ -31,6 +35,9 @@
         "channels": [
           {
             "id": "606b65e1dd934f70840bfef7",
+            "name": "testing public",
+            "service": "facebook",
+            "organizationId": "606b65d6dad38c03d2b70793",
             "__typename": "Channel"
           }
         ],
@@ -73,7 +80,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": false,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -189,7 +199,10 @@
               "channelsQuantity": 1,
               "description": "Simplify the noise and test out social media management tools.",
               "isCurrentPlan": false,
-              "highlights": ["Basic publishing tools", "Limited usage"],
+              "highlights": [
+                "Basic publishing tools",
+                "Limited usage"
+              ],
               "currency": "$",
               "basePrice": 0,
               "totalPrice": 0,
@@ -308,6 +321,7 @@
           "id": "606b65d6dad38c03d2b70793",
           "name": "test",
           "canEdit": true,
+          "canManageBilling": true,
           "role": "admin",
           "canMigrateToOneBuffer": {
             "canMigrate": false,
@@ -372,7 +386,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": false,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,
@@ -488,7 +505,10 @@
                 "channelsQuantity": 1,
                 "description": "Simplify the noise and test out social media management tools.",
                 "isCurrentPlan": false,
-                "highlights": ["Basic publishing tools", "Limited usage"],
+                "highlights": [
+                  "Basic publishing tools",
+                  "Limited usage"
+                ],
                 "currency": "$",
                 "basePrice": 0,
                 "totalPrice": 0,

--- a/packages/app-shell/src/common/graphql/account.js
+++ b/packages/app-shell/src/common/graphql/account.js
@@ -98,8 +98,36 @@ export const BILLING_FIELDS = gql`
   }
 `;
 
-export const QUERY_ACCOUNT = gql`
+export const ACCOUNT_ORGANIZATION_FIELDS = gql`
   ${BILLING_FIELDS}
+  fragment AccountOrganizationFields on AccountOrganization {
+    id
+    name
+    canEdit
+    canManageBilling
+    role
+    createdAt
+    isOneBufferOrganization
+    canMigrateToOneBuffer {
+      canMigrate
+      reasons
+    }
+    shouldDisplayInviteCTA
+    featureFlips
+    channels {
+      id
+      name
+      service
+      organizationId
+    }
+    billing {
+      ...BillingFields
+    }
+  }
+`;
+
+export const QUERY_ACCOUNT = gql`
+  ${ACCOUNT_ORGANIZATION_FIELDS}
   query GetAccount {
     account {
       id
@@ -109,48 +137,10 @@ export const QUERY_ACCOUNT = gql`
       isImpersonation
       shouldShowEmailVerificationCommunication
       currentOrganization {
-        id
-        name
-        canEdit
-        canManageBilling
-        role
-        createdAt
-        isOneBufferOrganization
-        canMigrateToOneBuffer {
-          canMigrate
-          reasons
-        }
-        shouldDisplayInviteCTA
-        featureFlips
-        billing {
-          ...BillingFields
-        }
-        channels {
-          id
-        }
+        ...AccountOrganizationFields
       }
       organizations {
-        id
-        name
-        canEdit
-        role
-        createdAt
-        isOneBufferOrganization
-        canMigrateToOneBuffer {
-          canMigrate
-          reasons
-        }
-        shouldDisplayInviteCTA
-        featureFlips
-        channels {
-          id
-          name
-          service
-          organizationId
-        }
-        billing {
-          ...BillingFields
-        }
+        ...AccountOrganizationFields
       }
       products {
         name

--- a/packages/app-shell/src/common/hooks/useOrgSwitcher.js
+++ b/packages/app-shell/src/common/hooks/useOrgSwitcher.js
@@ -20,6 +20,7 @@ function useOrgSwitcher() {
         currentOrganization: organizationSelected,
       },
     };
+
     client.writeQuery({
       query: QUERY_ACCOUNT,
       data: updatedData,


### PR DESCRIPTION
We do some manual cache changes when an organization is switched in
order to prevent over-fetching but if the fields in both
currentOrganization and organizations are not the same the query
write will fail to validate and break.

Using a fragment ensures that we request the same fields on both edges.