### PR TITLE
[FIX] Modal hidden under nav

### DIFF
--- a/packages/app-shell/src/components/Modal/index.jsx
+++ b/packages/app-shell/src/components/Modal/index.jsx
@@ -22,11 +22,38 @@ import TrialExpired from './modals/TrialExpired';
 import QuantityUpdate from './modals/QuantityUpdate';
 import { Paywall } from './modals/Paywall';
 
-import { shouldShowFreeUserStartTrialPrompt, shouldShowChannelConnectionPrompt, shouldShowPaywallModal } from './utils';
+import {
+  shouldShowFreeUserStartTrialPrompt,
+  shouldShowChannelConnectionPrompt,
+  shouldShowPaywallModal,
+} from './utils';
 
 const ModalWrapper = styled.div`
   > div {
     z-index: 1;
+    overflow: scroll;
+
+    // Hacky: The navigator has been forced on top of everything
+    // This is nbeeded for the paywall work.
+    // This below css handles makes it possible to scroll the modal into view.
+    @media screen and (max-height: 850px) {
+      justify-content: unset;
+      top: 60px;
+      flex-direction: column;
+
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: -300px;
+        left: 0;
+        width: 100px;
+        height: 400px;
+      }
+
+      > div > div {
+        top: 20px;
+      }
+    }
   }
 `;
 
@@ -183,7 +210,9 @@ const Modal = React.memo(({ modal, openModal }) => {
   return (
     <>
       {hasModal && (
-        <ModalWrapper><ModalContent modal={modal} closeAction={() => openModal(null)} /></ModalWrapper>
+        <ModalWrapper>
+          <ModalContent modal={modal} closeAction={() => openModal(null)} />
+        </ModalWrapper>
       )}
     </>
   );


### PR DESCRIPTION
Jira: [GROW-437](https://buffer.atlassian.net/browse/GROW-437)

Hacky fix but now the modal can be scrolled into view

👀  Would I be able to get someone to review this PR just as I tried many many different ways to fix this issue (including looking into making changes directly into the UI modal) I came up with this solution and used the awkward CSS child selectors to hopefully reduce the risk of breaking modal layouts throughout our applications 🤔  

Short loom video showing the bug and the new behaviour: https://www.loom.com/share/6d7adc275440463796e25b47cd979111?sharedAppSource=personal_library
