### PR TITLE
[GROW-440] remove top border summary

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.style.js
+++ b/packages/app-shell/src/components/Modal/modals/Summary/components/UpdatedPlanInfo.style.js
@@ -35,7 +35,6 @@ export const Section = styled.div`
   margin-top: 15px;
   padding: 15px 0;
   border-bottom: 1px ${grayLight} solid;
-  border-top: 1px ${grayLight} solid;
   flex-direction: column;
 `;
 


### PR DESCRIPTION
`slot-based-billing` OFF
<img width="947" alt="SBB OFF" src="https://user-images.githubusercontent.com/1514227/159446639-08b796d4-73fa-48a9-8e87-9add4ea48495.png">

`slot-based-billing` ON - before
<img width="932" alt="SBB ON Before" src="https://user-images.githubusercontent.com/1514227/159446651-4525071f-c518-4cf9-8dd5-5e35b220edb1.png">

`slot-based-billing` ON - after
<img width="930" alt="Screenshot 2022-03-22 at 16 07 50" src="https://user-images.githubusercontent.com/1514227/159446664-7eb63008-6b6c-4668-b525-7caca1a687f5.png">
