### PR TITLE
[GROW-439] Surface error message

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -53,6 +53,7 @@ const CardBody = ({
     updateSubscriptionQuantity,
     data: updateQuantityData,
     isProcessing,
+    error,
   } = useUpdateSubscriptionQuantity({
     user,
     channelsQuantity: channelsCount,
@@ -95,6 +96,11 @@ const CardBody = ({
             Change Plan
           </button>
         </Text>
+        {error && (
+          <Text type="help" hasError>
+            {error.message}
+          </Text>
+        )}
       </Header>
       <SectionContainer>
         <Section>


### PR DESCRIPTION
We were raising the error but never displaying it.
To test in dev, we can just add extra characters to the ID we use in the call to Stripe:
```
  await stripeClientLatest.subscriptionItems.update(
    // the gateway id is the stripe subscription item
    `${customer.subscription.plan.gatewayId}123`,
    {
      quantity: SubscriptionQuantity.newStrict(quantity),
      proration_behavior: prorationBehaviour,
    },
  )
```
https://github.com/bufferapp/core-authentication-service/blob/83b06046e572788a20b199a7901dcdd50bac7b01/shared/services/billing/gateways/StripeGateway/StripeGateway.updateSubscriptionQuantity.ts#L28-L35

Not sure where to display it,I added it under the description. Let me know if you think there is a better positioning.
<img width="519" alt="Screenshot 2022-03-23 at 09 12 28" src="https://user-images.githubusercontent.com/1514227/159610179-bb6911c4-ebad-4415-884d-469cd02869e8.png">
