### PR TITLE
[GROW-384] use full cycle name instead of abbreviation & update copy

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -5,7 +5,6 @@ import { Text, Button } from '@bufferapp/ui';
 
 import useChannelsCounter from '../../../../../common/hooks/useChannelsCounter';
 import useUpdateSubscriptionQuantity from '../../../../../common/hooks/useUpdateSubscriptionQuantity';
-import { getProductPriceCycleText } from '../../../../../common/utils/product';
 import Channels from '../../../../../common/components/Channels/Channels';
 import { calculateTotalSlotsPrice } from '../../../utils';
 

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -82,7 +82,6 @@ const CardBody = ({
           You&apos;re currently on the <strong>{planName}</strong> plan and
           you&apos;re paying{' '}
           <strong>
-            {' '}
             ${pricePerQuantity}/{planCycle}
           </strong>{' '}
           for {quantity} channel

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -82,7 +82,8 @@ const CardBody = ({
           You&apos;re currently on the <strong>{planName}</strong> plan and
           you&apos;re paying{' '}
           <strong>
-            {getProductPriceCycleText(pricePerQuantity, planCycle)}
+            {' '}
+            ${pricePerQuantity}/{planCycle}
           </strong>{' '}
           for {quantity} channel
           {quantity !== 1 ? 's' : ''}.{' '}

--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -82,10 +82,10 @@ const CardBody = ({
           You&apos;re currently on the <strong>{planName}</strong> plan and
           you&apos;re paying{' '}
           <strong>
-            ${pricePerQuantity}/{planCycle}
+            ${pricePerQuantity}/{planCycle} per channel
           </strong>{' '}
           for {quantity} channel
-          {quantity !== 1 ? 's' : ''}.{' '}
+          {quantity !== 1 ? 's' : ''}.
           <button
             type="button"
             onClick={(newData) => {


### PR DESCRIPTION
Before
<img width="517" alt="Screenshot 2022-03-23 at 09 20 36" src="https://user-images.githubusercontent.com/1514227/159611103-6bf47c98-5b0a-4cc1-84ee-556a19d83724.png">

After
<img width="521" alt="Screenshot 2022-03-23 at 09 27 46" src="https://user-images.githubusercontent.com/1514227/159611988-b24e82eb-7a75-415f-b3fd-48c5530fc2b2.png">

