### PR TITLE
Fix/grow 434 refactor logic planselector layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const ModalTesting = () => (
   <ModalContext.Consumer>
     {modal => (
       <button onClick={
-        () => {actions.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'renderModal' isUpgradeIntent: false })}
+        () => {actions.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'renderModal'})}
       }>Render Modal</button>
     )}
   </ModalContext.Consumer>
@@ -123,16 +123,6 @@ const ModalTesting = () => (
 ```
 #### Using CTAs for tracking
 In the method above, you'll notice that openModal accepts an object as a second paramater. The cta property is used for tracking. Use it when possible to allow for accurate tracking in Segment
-
-#### Using intentions
-Some places in our apps, the user's intent is to upgrade from Trial or from Free. For that, we only want to show 2 plan options (Essentials and Team) instead of 3. For these CTAs, pass in `isUpgradeIntent : true` as part of the second paramater in openModal:
-```jsx
-<button onClick={
-    () => {modal.openModal(MODALS.paymentMethod, { cta: 'upgradePlan', ctaButton: 'upgradePlan', isUpgradeIntent: true })}
-  }>
-  Upgrade
-</button>
-```
 
 ## Redering components in Product App
 

--- a/cypress/fixtures/accountObAgency.json
+++ b/cypress/fixtures/accountObAgency.json
@@ -2,7 +2,7 @@
     "data": {
       "account": {
         "id": "606b65d6dad38c9d20b70792",
-        "email": "ob_essential@buffer.com",
+        "email": "ob_agency@buffer.com",
         "createdAt": "2021-04-05T19:32:38.841Z",
         "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
         "isImpersonation": false,
@@ -719,6 +719,15 @@
       "billingUpdateSubscriptionQuantity": {
         "success": true,
         "__typename": "BillingResponse"
+      },
+      "billingUpdateSubscriptionPlan": {
+        "success": true,
+        "__typename": "BillingResponse"
+      },
+      "billingCreateSetupIntent": {
+        "clientSecret": "",
+        "success": true,
+        "__typename": "BillingCreateSetupIntentResponse"
       }
     }
   }

--- a/cypress/fixtures/accountObAgency.json
+++ b/cypress/fixtures/accountObAgency.json
@@ -1,0 +1,724 @@
+{
+    "data": {
+      "account": {
+        "id": "606b65d6dad38c9d20b70792",
+        "email": "ob_essential@buffer.com",
+        "createdAt": "2021-04-05T19:32:38.841Z",
+        "featureFlips": ["grantAnalyzeAccess", "sharedChannels", "engageRollOut"],
+        "isImpersonation": false,
+        "shouldShowEmailVerificationCommunication": true,
+        "currentOrganization": {
+          "id": "606b65d6dad38c03d2b70793",
+          "name": "test",
+          "canEdit": true,
+          "privileges": {
+            "canManageBilling": true,
+            "__typename": "AccountPrivileges"
+          },
+          "role": "admin",
+          "canMigrateToOneBuffer": {
+            "canMigrate": false,
+            "reasons": [
+              "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+            ],
+            "__typename": "CanMigrateToOneBuffer"
+          },
+          "createdAt": "2021-04-05T19:32:38.961Z",
+          "isOneBufferOrganization": true,
+          "shouldDisplayInviteCTA": false,
+          "featureFlips": [
+            "grantAnalyzeAccess",
+            "sharedChannels",
+            "engageRollOut"
+          ],
+          "channels": [
+            {
+              "id": "606b65e1dd934f70840bfef7",
+              "name": "testing public",
+              "service": "facebook",
+              "organizationId": "606b65d6dad38c03d2b70793",
+              "__typename": "Channel"
+            }
+          ],
+          "billing": {
+            "id": "606b65d6dad38c03d2b70793",
+            "canAccessAnalytics": true,
+            "canAccessEngagement": true,
+            "canAccessPublishing": true,
+            "paymentDetails": {
+              "hasPaymentDetails": true,
+              "__typename": "PaymentDetails"
+            },
+            "canStartTrial": false,
+            "subscription": {
+              "quantity": 10,
+              "interval": "yearly",
+              "periodEnd": "2022-08-04T21:25:40.000Z",
+              "isCanceledAtPeriodEnd": false,
+              "trial": null,
+              "plan": {
+                "id": "agency",
+                "name": "Agency",
+                "__typename": "OBPlan"
+              },
+              "__typename": "OBSubscription"
+            },
+            "channelSlotDetails": {
+              "flatFee": 0,
+              "currentQuantity": 2,
+              "chargableQuantity": 2,
+              "pricePerQuantity": 6,
+              "minimumQuantity": 1,
+              "__typename": "ChannelSlotDetails"
+            },
+            "changePlanOptions": [
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 3,
+                  "chargableQuantity": 3,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 3,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 6,
+                "totalPrice": 6,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "month",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 12,
+                "totalPrice": 12,
+                "discountPercentage": 0,
+                "discountNote": "",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Save $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "agency",
+                "planName": "Agency",
+                "planInterval": "month",
+                "channelsQuantity": 10,
+                "description": "Support a growing client base with features & pricing that scale with your business.",
+                "isCurrentPlan": true,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "free",
+                "planName": "Free",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Simplify the noise and test out social media management tools.",
+                "isCurrentPlan": false,
+                "highlights": ["Basic publishing tools", "Limited usage"],
+                "currency": "$",
+                "basePrice": 0,
+                "totalPrice": 0,
+                "discountPercentage": 0,
+                "discountNote": "0% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "",
+                "summary": {
+                  "details": [
+                    "10 scheduled posts",
+                    "3 social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "essentials",
+                "planName": "Essentials",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools"
+                ],
+                "currency": "$",
+                "basePrice": 5,
+                "totalPrice": 60,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $12/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "One user"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "team",
+                "planName": "Essentials + Team Pack",
+                "planInterval": "year",
+                "channelsQuantity": 1,
+                "description": "Collaborate with your team in one place & save time reporting.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              },
+              {
+                "planId": "agency",
+                "planName": "Agency",
+                "planInterval": "year",
+                "channelsQuantity": 10,
+                "description": "Support a growing client base with features & pricing that scale with your business.",
+                "isCurrentPlan": false,
+                "highlights": [
+                  "Advanced publishing tools",
+                  "Analytics & reporting",
+                  "Engagement tools",
+                  "Unlimited team members & clients",
+                  "Drafting & approval workflow tools",
+                  "Exportable PDF reports"
+                ],
+                "currency": "$",
+                "basePrice": 10,
+                "totalPrice": 120,
+                "discountPercentage": 17,
+                "discountNote": "17% Discount",
+                "priceNote": "Per social channel per month",
+                "absoluteSavings": "Saving $24/year",
+                "summary": {
+                  "details": [
+                    "Unlimited scheduled posts",
+                    "Unlimited social channels",
+                    "Unlimited users"
+                  ],
+                  "__typename": "OBPlanOptionSummary"
+                },
+                "isRecommended": false,
+                "downgradedMessage": "",
+                "channelSlotDetails": {
+                  "flatFee": 0,
+                  "currentQuantity": 0,
+                  "chargableQuantity": 0,
+                  "pricePerQuantity": 0,
+                  "minimumQuantity": 0,
+                  "__typename": "ChannelSlotDetails"
+                },
+                "__typename": "OBPlanOption"
+              }
+            ],
+            "__typename": "OBBilling"
+          },
+          "__typename": "AccountOrganization"
+        },
+        "organizations": [
+          {
+            "id": "606b65d6dad38c03d2b70793",
+            "name": "test",
+            "canEdit": true,
+            "privileges": {
+              "canManageBilling": true,
+              "__typename": "AccountPrivileges"
+            },
+            "role": "admin",
+            "canMigrateToOneBuffer": {
+              "canMigrate": false,
+              "reasons": [
+                "Customer 606b65d6dad38c03d2b70793 is missing the eligibility flag"
+              ],
+              "__typename": "CanMigrateToOneBuffer"
+            },
+            "createdAt": "2021-04-05T19:32:38.961Z",
+            "isOneBufferOrganization": true,
+            "shouldDisplayInviteCTA": false,
+            "featureFlips": [
+              "grantAnalyzeAccess",
+              "sharedChannels",
+              "engageRollOut"
+            ],
+            "channels": [
+              {
+                "id": "606b65e1dd934f70840bfef7",
+                "name": "testing public",
+                "service": "facebook",
+                "organizationId": "606b65d6dad38c03d2b70793",
+                "__typename": "Channel"
+              }
+            ],
+            "billing": {
+              "id": "606b65d6dad38c03d2b70793",
+              "canAccessAnalytics": true,
+              "canAccessEngagement": true,
+              "canAccessPublishing": true,
+              "paymentDetails": {
+                "hasPaymentDetails": true,
+                "__typename": "PaymentDetails"
+              },
+              "canStartTrial": false,
+              "subscription": {
+                "quantity": 1,
+                "interval": "year",
+                "periodEnd": "2022-08-04T21:25:40.000Z",
+                "isCanceledAtPeriodEnd": false,
+                "trial": null,
+                "plan": {
+                  "id": "essentials",
+                  "name": "Essentials",
+                  "__typename": "OBPlan"
+                },
+                "__typename": "OBSubscription"
+              },
+              "channelSlotDetails": {
+                "flatFee": 0,
+                "currentQuantity": 2,
+                "chargableQuantity": 2,
+                "pricePerQuantity": 6,
+                "minimumQuantity": 1,
+                "__typename": "ChannelSlotDetails"
+              },
+              "changePlanOptions": [
+                {
+                  "planId": "free",
+                  "planName": "Free",
+                  "planInterval": "month",
+                  "channelsQuantity": 1,
+                  "description": "Simplify the noise and test out social media management tools.",
+                  "isCurrentPlan": false,
+                  "highlights": ["Basic publishing tools", "Limited usage"],
+                  "currency": "$",
+                  "basePrice": 0,
+                  "totalPrice": 0,
+                  "discountPercentage": 0,
+                  "discountNote": "",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "",
+                  "summary": {
+                    "details": [
+                      "10 scheduled posts",
+                      "3 social channels",
+                      "One user"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                    "currentQuantity": 2,
+                    "chargableQuantity": 2,
+                    "pricePerQuantity": 6,
+                    "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                },
+                {
+                  "planId": "essentials",
+                  "planName": "Essentials",
+                  "planInterval": "month",
+                  "channelsQuantity": 1,
+                  "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                  "isCurrentPlan": false,
+                  "highlights": [
+                    "Advanced publishing tools",
+                    "Analytics & reporting",
+                    "Engagement tools"
+                  ],
+                  "currency": "$",
+                  "basePrice": 6,
+                  "totalPrice": 6,
+                  "discountPercentage": 0,
+                  "discountNote": "",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "Save $12/year",
+                  "summary": {
+                    "details": [
+                      "Unlimited scheduled posts",
+                      "Unlimited social channels",
+                      "One user"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                    "currentQuantity": 2,
+                    "chargableQuantity": 2,
+                    "pricePerQuantity": 6,
+                    "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                },
+                {
+                  "planId": "team",
+                  "planName": "Essentials + Team Pack",
+                  "planInterval": "month",
+                  "channelsQuantity": 1,
+                  "description": "Collaborate with your team in one place & save time reporting.",
+                  "isCurrentPlan": false,
+                  "highlights": [
+                    "Advanced publishing tools",
+                    "Analytics & reporting",
+                    "Engagement tools",
+                    "Unlimited team members & clients",
+                    "Drafting & approval workflow tools",
+                    "Exportable PDF reports"
+                  ],
+                  "currency": "$",
+                  "basePrice": 12,
+                  "totalPrice": 12,
+                  "discountPercentage": 0,
+                  "discountNote": "",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "Save $24/year",
+                  "summary": {
+                    "details": [
+                      "Unlimited scheduled posts",
+                      "Unlimited social channels",
+                      "Unlimited users"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                    "currentQuantity": 2,
+                    "chargableQuantity": 2,
+                    "pricePerQuantity": 6,
+                    "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                },
+                {
+                  "planId": "free",
+                  "planName": "Free",
+                  "planInterval": "year",
+                  "channelsQuantity": 1,
+                  "description": "Simplify the noise and test out social media management tools.",
+                  "isCurrentPlan": false,
+                  "highlights": ["Basic publishing tools", "Limited usage"],
+                  "currency": "$",
+                  "basePrice": 0,
+                  "totalPrice": 0,
+                  "discountPercentage": 0,
+                  "discountNote": "0% Discount",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "",
+                  "summary": {
+                    "details": [
+                      "10 scheduled posts",
+                      "3 social channels",
+                      "One user"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                    "currentQuantity": 2,
+                    "chargableQuantity": 2,
+                    "pricePerQuantity": 6,
+                    "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                },
+                {
+                  "planId": "essentials",
+                  "planName": "Essentials",
+                  "planInterval": "year",
+                  "channelsQuantity": 1,
+                  "description": "Get the most out of your creative with publishing, analytics & engagement tools.",
+                  "isCurrentPlan": false,
+                  "highlights": [
+                    "Advanced publishing tools",
+                    "Analytics & reporting",
+                    "Engagement tools"
+                  ],
+                  "currency": "$",
+                  "basePrice": 5,
+                  "totalPrice": 60,
+                  "discountPercentage": 17,
+                  "discountNote": "17% Discount",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "Saving $12/year",
+                  "summary": {
+                    "details": [
+                      "Unlimited scheduled posts",
+                      "Unlimited social channels",
+                      "One user"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                },
+                {
+                  "planId": "team",
+                  "planName": "Essentials + Team Pack",
+                  "planInterval": "year",
+                  "channelsQuantity": 1,
+                  "description": "Collaborate with your team in one place & save time reporting.",
+                  "isCurrentPlan": false,
+                  "highlights": [
+                    "Advanced publishing tools",
+                    "Analytics & reporting",
+                    "Engagement tools",
+                    "Unlimited team members & clients",
+                    "Drafting & approval workflow tools",
+                    "Exportable PDF reports"
+                  ],
+                  "currency": "$",
+                  "basePrice": 10,
+                  "totalPrice": 120,
+                  "discountPercentage": 17,
+                  "discountNote": "17% Discount",
+                  "priceNote": "Per social channel per month",
+                  "absoluteSavings": "Saving $24/year",
+                  "summary": {
+                    "details": [
+                      "Unlimited scheduled posts",
+                      "Unlimited social channels",
+                      "Unlimited users"
+                    ],
+                    "__typename": "OBPlanOptionSummary"
+                  },
+                  "isRecommended": false,
+                  "downgradedMessage": "",
+                  "channelSlotDetails": {
+                    "flatFee": 0,
+                  "currentQuantity": 2,
+                  "chargableQuantity": 2,
+                  "pricePerQuantity": 6,
+                  "minimumQuantity": 1,
+                    "__typename": "ChannelSlotDetails"
+                  },
+                  "__typename": "OBPlanOption"
+                }
+              ],
+              "__typename": "OBBilling"
+            },
+            "__typename": "AccountOrganization"
+          }
+        ],
+        "products": [
+          {
+            "name": "publish",
+            "userId": "606b65d760292104ad6ef6b5",
+            "__typename": "ProductLink"
+          },
+          {
+            "name": "analyze",
+            "userId": "606b65d6dad38c9d20b70792",
+            "__typename": "ProductLink"
+          },
+          {
+            "name": "engage",
+            "userId": "606b65d6dad38c9d20b70792",
+            "__typename": "ProductLink"
+          }
+        ],
+        "__typename": "Account"
+      },
+      "billingUpdateSubscriptionQuantity": {
+        "success": true,
+        "__typename": "BillingResponse"
+      }
+    }
+  }

--- a/cypress/fixtures/accountObFree.json
+++ b/cypress/fixtures/accountObFree.json
@@ -195,6 +195,48 @@
               "__typename": "OBPlanOption"
             },
             {
+              "planId": "agency",
+              "planName": "Agency",
+              "planInterval": "month",
+              "channelsQuantity": 10,
+              "description": "Support a growing client base with features & pricing that scale with your business.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Draft approval workflows",
+                "Exportable PDF reports",
+                "Agency friendly pricing"
+              ],
+              "currency": "$",
+              "basePrice": 120,
+              "totalPrice": 120,
+              "discountPercentage": 0,
+              "discountNote": "",
+              "priceNote": "For 10 social channels. Add additional channels for $6 per month",
+              "absoluteSavings": "Save $240/year",
+              "summary": {
+                "details": [
+                  "2000 scheduled posts",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 120,
+                "currentQuantity": 10,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 6,
+                "minimumQuantity": 10,
+                "__typename": "OBPlanOption"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
               "planId": "free",
               "planName": "Free",
               "planInterval": "year",
@@ -306,6 +348,49 @@
                 "chargableQuantity": 0,
                 "pricePerQuantity": 0,
                 "minimumQuantity": 0,
+                "__typename": "ChannelSlotDetails"
+              },
+              "__typename": "OBPlanOption"
+            },
+            {
+              "planId": "agency",
+              "planName": "Agency",
+              "planInterval": "year",
+              "channelsQuantity": 10,
+              "description": "Support a growing client base with features & pricing that scale with your business.",
+              "isCurrentPlan": false,
+              "highlights": [
+                "Advanced publishing tools",
+                "Analytics & reporting",
+                "Engagement tools",
+                "Unlimited team members & clients",
+                "Draft approval workflows",
+                "Exportable PDF reports",
+                "Agency friendly pricing"
+              ],
+              
+              "currency": "$",
+              "basePrice": 100,
+              "totalPrice": 1200,
+              "discountPercentage": 17,
+              "discountNote": "17% Discount",
+              "priceNote": "For 10 social channels. Add additional channels for $5 per month",
+              "absoluteSavings": "Saving $240/year",
+              "summary": {
+                "details": [
+                  "2000 scheduled posts",
+                  "Unlimited users"
+                ],
+                "__typename": "OBPlanOptionSummary"
+              },
+              "isRecommended": false,
+              "downgradedMessage": "",
+              "channelSlotDetails": {
+                "flatFee": 1200,
+                "currentQuantity": 10,
+                "chargableQuantity": 0,
+                "pricePerQuantity": 60,
+                "minimumQuantity": 10,
                 "__typename": "ChannelSlotDetails"
               },
               "__typename": "OBPlanOption"

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -15,20 +15,13 @@ describe('Modal', () => {
       });
     });
 
-    it('should render the Plan Selector Modal with Essentials plan monthly selected when the users current plan is Free monthly', () => {
-      cy.get('#render_plan_selector').click();
-
-      cy.get('#essentials_month').should('exist');
-      cy.get('#essentials_month').should('have.attr', 'aria-label', 'checked');
-    });
-
     it('should render the Plan Selector Modal with Essentials and Team displayed', () => {
       cy.get('#render_plan_selector').click();
 
-      cy.get('#essentials_month').should('exist');
-      cy.get('#team_month').should('exist');
-      cy.get('#free_month').should('not.exist');
-      cy.get('#agency_month').should('not.exist');
+      cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+      cy.get('#free_year').should('not.exist');
+      cy.get('#agency_year').should('not.exist');
     });
 
     it('should render the Plan Selector Modal with Agency CTA displayed in footer', () => {

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -59,7 +59,7 @@ describe('Modal', () => {
       // Plans NOT displayed
       cy.get('#agency_year').should('not.exist');
 
-      // Try agency should be displayed
+      // Try Agency should be displayed
       cy.get('#agency_plan_section').should('exist');
 
       // Try Free should NOT be displayed
@@ -92,7 +92,7 @@ describe('Modal', () => {
       // Plans NOT displayed
       cy.get('#agency_year').should('not.exist');
 
-      // Try agency should be displayed
+      // Try Agency should be displayed
       cy.get('#agency_plan_section').should('exist');
 
       // Try Free should NOT be displayed
@@ -100,6 +100,40 @@ describe('Modal', () => {
 
       // It should default to Team year
       cy.get('#team_year').should('have.attr', 'aria-label', 'checked');
+    });
+  });
+
+  describe('Plan selector - Agency plan', () => {
+    beforeEach(() => {
+      cy.fixture('accountObAgency').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        });
+        cy.visit('/');
+      });
+    });
+
+    it('should render the Plan Selector Modal with Essentials, Team and Agency plans displayed', () => {
+      cy.get('#render_plan_selector').click();
+
+      // Plans displayed
+
+      cy.get('#essentials_month').should('exist');
+      cy.get('#team_month').should('exist');
+      cy.get('#agency_month').should('exist');
+
+      // Plans NOT displayed
+      cy.get('#free_month').should('not.exist');
+
+      // Try Free should be displayed
+      cy.get('#free_plan_section').should('exist');
+
+      // Try Agency should NOT be displayed
+      cy.get('#agency_plan_section').should('not.exist');
+
+      // It should default to Team year
+      cy.get('#agency_month').should('have.attr', 'aria-label', 'checked');
     });
   });
 });

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -35,6 +35,31 @@ describe('Modal', () => {
       // It should default to Esstential year
       cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
+
+    it('should display Agency plan when clicking on Try Agency', () => {
+      cy.get('#render_plan_selector').click();
+
+      // Try agency should be displayed
+      cy.get('#agency_plan_section').should('exist');
+      cy.get('#try_agency_plan').click();
+
+      // Plans displayed
+      cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+      cy.get('#agency_year').should('exist');
+
+      // Plans NOT displayed
+      cy.get('#free_year').should('not.exist');
+
+      // Try Free should be displayed
+      cy.get('#free_plan_section').should('exist');
+
+      // Try Agency should NOT be displayed
+      cy.get('#agency_plan_section').should('not.exist');
+
+      // It should default to Esstential year
+      cy.get('#agency_year').should('have.attr', 'aria-label', 'checked');
+    });
   });
 
   describe('Plan selector - Essentials plan', () => {

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -57,7 +57,7 @@ describe('Modal', () => {
       // Try Agency should NOT be displayed
       cy.get('#agency_plan_section').should('not.exist');
 
-      // It should default to Esstential year
+      // It should default to Agency year
       cy.get('#agency_year').should('have.attr', 'aria-label', 'checked');
     });
   });
@@ -143,7 +143,6 @@ describe('Modal', () => {
       cy.get('#render_plan_selector').click();
 
       // Plans displayed
-
       cy.get('#essentials_month').should('exist');
       cy.get('#team_month').should('exist');
       cy.get('#agency_month').should('exist');
@@ -157,8 +156,20 @@ describe('Modal', () => {
       // Try Agency should NOT be displayed
       cy.get('#agency_plan_section').should('not.exist');
 
-      // It should default to Team year
+      // It should default to Agency month
       cy.get('#agency_month').should('have.attr', 'aria-label', 'checked');
+    });
+
+    it('should display Free plan when clicking on Try Free', () => {
+      cy.get('#render_plan_selector').click();
+
+      // Try Free should be displayed
+      cy.get('#free_plan_section').should('exist');
+      cy.get('#try_free_plan').click();
+
+      // Confirmation success modal should be displayed
+      cy.get('#confirmation').should('exist');
+      cy.get('#confirmation').click();
     });
   });
 });

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -1,61 +1,76 @@
 const REACT_APP_API_GATEWAY_URL_MATCHER = /https:\/\/(graph\.buffer|graph\.local\.buffer).com\//;
 
 describe('Modal', () => {
-  describe('Publish product - OB Free Plan', () => {
-    before(() => {
+  describe('Plan selector - Free plan', () => {
+    beforeEach(() => {
       cy.fixture('accountObFree').then((account) => {
         cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
           status: 200,
           body: account,
         }).as('getAccount');
-
-        cy.visit(Cypress.env('PUBLISH_URL'));
+        cy.visit('/');
         cy.wait('@getAccount').then(({ request }) => {
           cy.task('log', `Request finished. Request data: ${request}`);
         });
       });
     });
 
-    it('should render the Start Trial Modal', () => {
-      cy.get('#start-trial-modal').should('exist');
+    it('should render the Plan Selector Modal with Essentials plan monthly selected when the users current plan is Free monthly', () => {
+      cy.get('#render_plan_selector').click();
+
+      cy.get('#essentials_month').should('exist');
+      cy.get('#essentials_month').should('have.attr', 'aria-label', 'checked');
+    });
+
+    it('should render the Plan Selector Modal with Essentials and Team displayed', () => {
+      cy.get('#render_plan_selector').click();
+
+      cy.get('#essentials_month').should('exist');
+      cy.get('#team_month').should('exist');
+      cy.get('#free_month').should('not.exist');
+      cy.get('#agency_month').should('not.exist');
+    });
+
+    it('should render the Plan Selector Modal with Agency CTA displayed in footer', () => {
+      cy.get('#render_plan_selector').click();
+
+      cy.get('#agency_plan_section').should('exist');
+      cy.get('#agency_month').should('not.exist');
     });
   });
-  describe('Analyze product - OB no channels', () => {
-    before(() => {
-      cy.fixture('accountObEssentialNoChannels').then((account) => {
+
+  describe('Plan selector - Essentials plan', () => {
+    beforeEach(() => {
+      cy.fixture('accountObEssential').then((account) => {
         cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
           status: 200,
           body: account,
-        }).as('getAccount');
-
-        cy.visit(Cypress.env('ANALYZE_URL'));
-        cy.wait('@getAccount').then(({ request }) => {
-          cy.task('log', `Request finished. Request data: ${request}`);
         });
+        cy.visit('/');
       });
     });
 
-    it('should render Channel Connection prompt modal', () => {
-      cy.get('#channel-connection-prompt').should('exist');
-    });
-  });
-  describe('Engage product - OB no channels', () => {
-    before(() => {
-      cy.fixture('accountObEssentialNoChannels').then((account) => {
-        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
-          status: 200,
-          body: account,
-        }).as('getAccount');
+    it('should render the Plan Selector Modal with Essentials plan yearly selected when this is the current users plan', () => {
+      cy.get('#render_plan_selector').click();
 
-        cy.visit(Cypress.env('ENGAGE_URL'));
-        cy.wait('@getAccount').then(({ request }) => {
-          cy.task('log', `Request finished. Request data: ${request}`);
-        });
-      });
+      cy.get('#essentials_year').should('exist');
+      cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
 
-    it('should render Channel Connection prompt modal', () => {
-      cy.get('#channel-connection-prompt').should('exist');
+    it('should render the Plan Selector Modal with Free, Essentials and Team plans displayed', () => {
+      cy.get('#render_plan_selector').click();
+
+      cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+      cy.get('#free_year').should('exist');
+      cy.get('#agency_year').should('not.exist');
+    });
+
+    it('should render the Plan Selector Modal with Agency CTA displayed in footer', () => {
+      cy.get('#render_plan_selector').click();
+
+      cy.get('#agency_plan_section').should('exist');
+      cy.get('#agency_month').should('not.exist');
     });
   });
 });

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -18,17 +18,22 @@ describe('Modal', () => {
     it('should render the Plan Selector Modal with Essentials and Team displayed', () => {
       cy.get('#render_plan_selector').click();
 
+      // Plans displayed
       cy.get('#essentials_year').should('exist');
       cy.get('#team_year').should('exist');
+
+      // Plans NOT displayed
       cy.get('#free_year').should('not.exist');
       cy.get('#agency_year').should('not.exist');
-    });
 
-    it('should render the Plan Selector Modal with Agency CTA displayed in footer', () => {
-      cy.get('#render_plan_selector').click();
-
+      // Try agency should be displayed
       cy.get('#agency_plan_section').should('exist');
-      cy.get('#agency_month').should('not.exist');
+
+      // Try Free should NOT be displayed
+      cy.get('#free_plan_section').should('not.exist');
+
+      // It should default to Esstential year
+      cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
   });
 
@@ -43,27 +48,58 @@ describe('Modal', () => {
       });
     });
 
-    it('should render the Plan Selector Modal with Essentials plan yearly selected when this is the current users plan', () => {
+    it('should render the Plan Selector Modal with Free, Essentials and Team plans displayed', () => {
       cy.get('#render_plan_selector').click();
 
+      // Plans displayed
+      cy.get('#free_year').should('exist');
       cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+
+      // Plans NOT displayed
+      cy.get('#agency_year').should('not.exist');
+
+      // Try agency should be displayed
+      cy.get('#agency_plan_section').should('exist');
+
+      // Try Free should NOT be displayed
+      cy.get('#free_lan_section').should('not.exist');
+
+      // It should default to Esstential year
       cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
+    });
+  });
+
+  describe('Plan selector - Team plan', () => {
+    beforeEach(() => {
+      cy.fixture('accountObTeam').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        });
+        cy.visit('/');
+      });
     });
 
     it('should render the Plan Selector Modal with Free, Essentials and Team plans displayed', () => {
       cy.get('#render_plan_selector').click();
 
+      // Plans displayed
+      cy.get('#free_year').should('exist');
       cy.get('#essentials_year').should('exist');
       cy.get('#team_year').should('exist');
-      cy.get('#free_year').should('exist');
+
+      // Plans NOT displayed
       cy.get('#agency_year').should('not.exist');
-    });
 
-    it('should render the Plan Selector Modal with Agency CTA displayed in footer', () => {
-      cy.get('#render_plan_selector').click();
-
+      // Try agency should be displayed
       cy.get('#agency_plan_section').should('exist');
-      cy.get('#agency_month').should('not.exist');
+
+      // Try Free should NOT be displayed
+      cy.get('#free_lan_section').should('not.exist');
+
+      // It should default to Team year
+      cy.get('#team_year').should('have.attr', 'aria-label', 'checked');
     });
   });
 });

--- a/cypress/integration/modal/modal.spec.js
+++ b/cypress/integration/modal/modal.spec.js
@@ -32,7 +32,7 @@ describe('Modal', () => {
       // Try Free should NOT be displayed
       cy.get('#free_plan_section').should('not.exist');
 
-      // It should default to Esstential year
+      // It should default to Essentials year
       cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
 
@@ -90,7 +90,7 @@ describe('Modal', () => {
       // Try Free should NOT be displayed
       cy.get('#free_lan_section').should('not.exist');
 
-      // It should default to Esstential year
+      // It should default to Essentials year
       cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
   });

--- a/cypress/integration/modal/productRelated.spec.js
+++ b/cypress/integration/modal/productRelated.spec.js
@@ -1,0 +1,61 @@
+const REACT_APP_API_GATEWAY_URL_MATCHER = /https:\/\/(graph\.buffer|graph\.local\.buffer).com\//;
+
+describe('Modal', () => {
+  describe('Publish product - OB Free Plan', () => {
+    before(() => {
+      cy.fixture('accountObFree').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        }).as('getAccount');
+
+        cy.visit(Cypress.env('PUBLISH_URL'));
+        cy.wait('@getAccount').then(({ request }) => {
+          cy.task('log', `Request finished. Request data: ${request}`);
+        });
+      });
+    });
+
+    it('should render the Start Trial Modal', () => {
+      cy.get('#start-trial-modal').should('exist');
+    });
+  });
+  describe('Analyze product - OB no channels', () => {
+    before(() => {
+      cy.fixture('accountObEssentialNoChannels').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        }).as('getAccount');
+
+        cy.visit(Cypress.env('ANALYZE_URL'));
+        cy.wait('@getAccount').then(({ request }) => {
+          cy.task('log', `Request finished. Request data: ${request}`);
+        });
+      });
+    });
+
+    it('should render Channel Connection prompt modal', () => {
+      cy.get('#channel-connection-prompt').should('exist');
+    });
+  });
+  describe('Engage product - OB no channels', () => {
+    before(() => {
+      cy.fixture('accountObEssentialNoChannels').then((account) => {
+        cy.intercept('POST', REACT_APP_API_GATEWAY_URL_MATCHER, {
+          status: 200,
+          body: account,
+        }).as('getAccount');
+
+        cy.visit(Cypress.env('ENGAGE_URL'));
+        cy.wait('@getAccount').then(({ request }) => {
+          cy.task('log', `Request finished. Request data: ${request}`);
+        });
+      });
+    });
+
+    it('should render Channel Connection prompt modal', () => {
+      cy.get('#channel-connection-prompt').should('exist');
+    });
+  });
+});

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -56,18 +56,19 @@ describe('Navigator', () => {
       cy.contains('Upgrade').should('exist');
       cy.contains('Upgrade').click();
 
+      // Plans displayed
       cy.get('#essentials_year').should('exist');
       cy.get('#team_year').should('exist');
+
+      // Plans NOT displayed
       cy.get('#free_year').should('not.exist');
       cy.get('#agency_year').should('not.exist');
-    });
 
-    it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {
-      cy.contains('Upgrade').should('exist');
-      cy.contains('Upgrade').click();
-
+      // Try agency should be displayed
       cy.get('#agency_plan_section').should('exist');
-      cy.get('#agency_year').should('not.exist');
+
+      // Try Free should NOT be displayed
+      cy.get('#free_plan_section').should('not.exist');
     });
   });
 

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -69,6 +69,9 @@ describe('Navigator', () => {
 
       // Try Free should NOT be displayed
       cy.get('#free_plan_section').should('not.exist');
+
+      // It should default to Essentials year
+      cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
     });
   });
 

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -52,10 +52,22 @@ describe('Navigator', () => {
       cy.contains('Upgrade').should('exist');
     });
 
-    it('a user can upgrade to essentials after clicking the upgrade button', () => {
-      cy.get('#upgradeCTA').click();
-      cy.get('#essentials_year').should('exist');
-      cy.get('#essentials_year').should('have.attr', 'aria-label', 'checked');
+    it('a user on the Free plan should be able click Upgrade and see essentials or team plan displayed', () => {
+      cy.contains('Upgrade').should('exist');
+      cy.contains('Upgrade').click();
+
+      cy.get('#essentials_month').should('exist');
+      cy.get('#team_month').should('exist');
+      cy.get('#free_month').should('not.exist');
+      cy.get('#agency_month').should('not.exist');
+    });
+
+    it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {
+      cy.contains('Upgrade').should('exist');
+      cy.contains('Upgrade').click();
+
+      cy.get('#agency_plan_section').should('exist');
+      cy.get('#agency_month').should('not.exist');
     });
   });
 
@@ -81,6 +93,24 @@ describe('Navigator', () => {
 
     it('does not have an invite team CTA', () => {
       cy.get('#inviteTeamCTA').should('not.exist');
+    });
+
+    it('a user on the Free plan should be able click Upgrade and see essentials or team plan displayed', () => {
+      cy.contains('Upgrade').should('exist');
+      cy.contains('Upgrade').click();
+
+      cy.get('#essentials_month').should('exist');
+      cy.get('#team_month').should('exist');
+      cy.get('#free_month').should('not.exist');
+      cy.get('#agency_month').should('not.exist');
+    });
+
+    it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {
+      cy.contains('Upgrade').should('exist');
+      cy.contains('Upgrade').click();
+
+      cy.get('#agency_plan_section').should('exist');
+      cy.get('#agency_month').should('not.exist');
     });
   });
 

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -56,10 +56,10 @@ describe('Navigator', () => {
       cy.contains('Upgrade').should('exist');
       cy.contains('Upgrade').click();
 
-      cy.get('#essentials_month').should('exist');
-      cy.get('#team_month').should('exist');
-      cy.get('#free_month').should('not.exist');
-      cy.get('#agency_month').should('not.exist');
+      cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+      cy.get('#free_year').should('not.exist');
+      cy.get('#agency_year').should('not.exist');
     });
 
     it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {
@@ -67,7 +67,7 @@ describe('Navigator', () => {
       cy.contains('Upgrade').click();
 
       cy.get('#agency_plan_section').should('exist');
-      cy.get('#agency_month').should('not.exist');
+      cy.get('#agency_year').should('not.exist');
     });
   });
 
@@ -99,10 +99,10 @@ describe('Navigator', () => {
       cy.contains('Upgrade').should('exist');
       cy.contains('Upgrade').click();
 
-      cy.get('#essentials_month').should('exist');
-      cy.get('#team_month').should('exist');
-      cy.get('#free_month').should('not.exist');
-      cy.get('#agency_month').should('not.exist');
+      cy.get('#essentials_year').should('exist');
+      cy.get('#team_year').should('exist');
+      cy.get('#free_year').should('not.exist');
+      cy.get('#agency_year').should('not.exist');
     });
 
     it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {

--- a/cypress/integration/navigator/navigator.spec.js
+++ b/cypress/integration/navigator/navigator.spec.js
@@ -94,24 +94,6 @@ describe('Navigator', () => {
     it('does not have an invite team CTA', () => {
       cy.get('#inviteTeamCTA').should('not.exist');
     });
-
-    it('a user on the Free plan should be able click Upgrade and see essentials or team plan displayed', () => {
-      cy.contains('Upgrade').should('exist');
-      cy.contains('Upgrade').click();
-
-      cy.get('#essentials_year').should('exist');
-      cy.get('#team_year').should('exist');
-      cy.get('#free_year').should('not.exist');
-      cy.get('#agency_year').should('not.exist');
-    });
-
-    it('a user on the Free plan should be able click Upgrade and see the agency cta displayed in footer', () => {
-      cy.contains('Upgrade').should('exist');
-      cy.contains('Upgrade').click();
-
-      cy.get('#agency_plan_section').should('exist');
-      cy.get('#agency_month').should('not.exist');
-    });
   });
 
   describe('OB Team Plan', () => {

--- a/packages/app-shell/src/common/hooks/useChannelsCounter.js
+++ b/packages/app-shell/src/common/hooks/useChannelsCounter.js
@@ -61,14 +61,6 @@ const useChannelsCounter = (
     }
 
     if (
-      planId === 'free' &&
-      channelsCount > 3 &&
-      channelCountMessageStatus === null
-    ) {
-      setChannelCountMessageStatus(freePlanLimitMessageStatus);
-    }
-
-    if (
       planId === 'agency' &&
       channelsCount >= minimumQuantity &&
       channelCountMessageStatus !== null

--- a/packages/app-shell/src/common/hooks/useChannelsCounter.js
+++ b/packages/app-shell/src/common/hooks/useChannelsCounter.js
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react';
 
-import {
-  getFreePlanChannelInputMessaging,
-  getAgencyPlanMinimumChannelInputMessaging,
-} from '../../components/Modal/utils';
+import { getAgencyPlanMinimumChannelInputMessaging } from '../../components/Modal/utils';
 
 function handleChannelsCountConditions(
   planId,
@@ -20,7 +17,6 @@ function handleChannelsCountConditions(
 
 const agencyPlanLimitMessageStatus =
   getAgencyPlanMinimumChannelInputMessaging();
-const freePlanLimitMessageStatus = getFreePlanChannelInputMessaging();
 
 const useChannelsCounter = (
   planId,

--- a/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
+++ b/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
@@ -30,7 +30,7 @@ const useUpdateSubscriptionPlan = ({
     if (!user || !plan) {
       // eslint-disable-next-line no-console
       console.error(
-        'Could not update plan because either: user, plan are undefined'
+        'Could not update plan because either: user or plan are undefined'
       );
       return;
     }

--- a/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
+++ b/packages/app-shell/src/common/hooks/useUpdateSubscriptionPlan.js
@@ -27,10 +27,10 @@ const useUpdateSubscriptionPlan = ({
   );
 
   useEffect(() => {
-    if (!user || !plan || !hasPaymentMethod) {
+    if (!user || !plan) {
       // eslint-disable-next-line no-console
       console.error(
-        'Could not update plan because either: user, plan or paymentDetails are undefined'
+        'Could not update plan because either: user, plan are undefined'
       );
       return;
     }

--- a/packages/app-shell/src/common/utils/user.js
+++ b/packages/app-shell/src/common/utils/user.js
@@ -5,6 +5,12 @@ export function isFreeUser(user) {
 }
 
 export function isAgencyUser(user) {
+  if (!user) {
+    console.warn(
+      'Warning: isAgencyUser - user was undefined. This could lead to unexpected behaviour.'
+    );
+  }
+
   return (
     user?.currentOrganization?.billing?.subscription?.plan?.id === 'agency'
   );
@@ -15,6 +21,12 @@ export function userCanStartFreeTrial(user) {
 }
 
 export function isOnAgencyTrial(user) {
+  if (!user) {
+    console.warn(
+      'Warning: isOnAgencyTrial - user was undefined. This could lead to unexpected behaviour.'
+    );
+  }
+
   const isOnAgencyPlan = isAgencyUser(user);
   if (isOnAgencyPlan) {
     return user?.currentOrganization?.billing?.subscription?.trial?.isActive;

--- a/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Confirmation/index.jsx
@@ -101,6 +101,7 @@ const Screen = ({
       <Text type="p">{description}</Text>
       <ButtonContainer stayedOnSamePlan={stayedOnSamePlan}>
         <Button
+          id="confirmation"
           type="primary"
           onClick={() => {
             closeModal();

--- a/packages/app-shell/src/components/Modal/modals/PaymentMethod/components/Form.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaymentMethod/components/Form.jsx
@@ -28,7 +28,6 @@ const Form = ({
   openSuccess,
   plan,
   isTrial,
-  isUpgradeIntent,
   canManageBilling,
   newPrice,
   channelCounterMessageStatus,
@@ -146,7 +145,7 @@ const Form = ({
             <Footer>
               <Button
                 type="text"
-                onClick={() => openPlans(isUpgradeIntent)}
+                onClick={() => openPlans()}
                 label="Go back to plans"
                 icon={<ArrowLeftIcon />}
               />

--- a/packages/app-shell/src/components/Modal/modals/PaymentMethod/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PaymentMethod/index.jsx
@@ -34,9 +34,8 @@ const PaymentMethod = () => {
             return (
               <StripeProvider>
                 <Form
-                  openPlans={(isUpgradeIntent) => {
+                  openPlans={() => {
                     openModal(MODALS.planSelector, {
-                      isUpgradeIntent,
                       cta,
                       ctaButton: 'goBackToPlanSelection',
                       ctaView: modal,
@@ -58,7 +57,6 @@ const PaymentMethod = () => {
                   canManageBilling={
                     user?.currentOrganization?.privileges?.canManageBilling
                   }
-                  isUpgradeIntent={modalData?.isUpgradeIntent}
                   newPrice={modalData?.newPrice}
                   channelCounterMessageStatus={
                     modalData?.channelCounterMessageStatus

--- a/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Paywall/components/Ctas.jsx
@@ -40,45 +40,46 @@ const Content = ({ openModal }) => {
     }
   }, [trial]);
 
-  return (<>
-    <styles.CTAs>
-      <Button
-        type="primary"
-        disabled={processing}
-        onClick={() => {
-          if (canStartTrial) {
-            startTrial()
-          } else {
-            openModal(MODALS.planSelector, {
-              cta,
-              ctaButton: `paywall-${cta}-1`,
-              isUpgradeIntent: true,
-            });
+  return (
+    <>
+      <styles.CTAs>
+        <Button
+          type="primary"
+          disabled={processing}
+          onClick={() => {
+            if (canStartTrial) {
+              startTrial();
+            } else {
+              openModal(MODALS.planSelector, {
+                cta,
+                ctaButton: `paywall-${cta}-1`,
+              });
+            }
+          }}
+          label={ctaLabel}
+        />
+        <Link newTab href={`https://buffer.com/${product}`}>
+          Learn more
+        </Link>
+        <Text>No credit card required</Text>
+        <Error
+          error={
+            error
+              ? {
+                  message: error.message,
+                }
+              : null
           }
-        }}
-        label={ctaLabel}
-      />
-      <Link newTab href={`https://buffer.com/${product}`}>Learn more</Link>
-      <Text>No credit card required</Text>
-      <Error
-        error={
-          error
-            ? {
-                message: error.message,
-              }
-            : null
-        }
-      />
-    </styles.CTAs>
+        />
+      </styles.CTAs>
     </>
   );
 };
 
 export const Ctas = () => {
-  return (<ModalContext.Consumer>
-    {({ openModal }) => (
-      <Content openModal={openModal} />
-    )}
-  </ModalContext.Consumer>);
+  return (
+    <ModalContext.Consumer>
+      {({ openModal }) => <Content openModal={openModal} />}
+    </ModalContext.Consumer>
+  );
 };
-

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
@@ -9,7 +9,7 @@ function AgencyPlanSection(props) {
   const { ctaAction } = props;
 
   return (
-    <Container>
+    <Container id="agency_plan_section">
       <Text htmlFor="agencyPlan" type="agency">
         Need more than 10 channels?{''}{' '}
         <Button

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/AgencyPlanSection.jsx
@@ -13,6 +13,7 @@ function AgencyPlanSection(props) {
       <Text htmlFor="agencyPlan" type="agency">
         Need more than 10 channels?{''}{' '}
         <Button
+          id="try_agency_plan"
           type="text"
           onClick={() => ctaAction()}
           label="Try our Agency plan"

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
@@ -13,6 +13,7 @@ function FreePlanSection(props) {
       <Text htmlFor="foo" type="help">
         Looking for basic publishing tools?{''}{' '}
         <Button
+          id="try_free_plan"
           type="text"
           onClick={() => ctaAction()}
           label="Downgrade to our Free plan"

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/FreePlanSection.jsx
@@ -9,7 +9,7 @@ function FreePlanSection(props) {
   const { ctaAction } = props;
 
   return (
-    <Container>
+    <Container id="free_plan_section">
       <Text htmlFor="foo" type="help">
         Looking for basic publishing tools?{''}{' '}
         <Button

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -174,18 +174,15 @@ export const PlanSelectorContainer = ({
   }, [monthlyBilling]);
 
   useEffect(() => {
-    handleUpgradeIntent(
-      selectedPlan.planId,
-      monthlyBilling,
-      updateSelectedPlan
-    );
-
     updateButton(selectedPlan, channelsCount);
   }, [selectedPlan]);
 
   useEffect(() => {
     updateButton(selectedPlan, channelsCount);
 
+    // When the channel count changes and we are on the Free plan
+    // We do this to automatically switch the user to the essentials plan
+    // as Free plans can have a max of 3 channels
     if (
       selectedPlan.planId === 'free' &&
       channelsCount > selectedPlanMinimumQuantity

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -280,7 +280,6 @@ export const PlanSelectorContainer = ({
         <ButtonContainer>
           <Button
             type="primary"
-            id="ubmitButton"
             onClick={() => {
               action({
                 plan: selectedPlan,

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -46,7 +46,6 @@ import {
 
 import {
   calculateTotalSlotsPrice,
-  handleUpgradeIntent,
   getAvailablePlansForDisplay,
 } from '../../../utils';
 

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/components/PlanSelectorContainer.jsx
@@ -57,7 +57,6 @@ export const PlanSelectorContainer = ({
   trialInfo,
   openSuccess,
   isFreePlan,
-  isUpgradeIntent,
 }) => {
   const { isEnabled: splitSBBEnabled } = useSplitEnabled('slot-based-billing');
   const planOptions = changePlanOptions;
@@ -268,7 +267,6 @@ export const PlanSelectorContainer = ({
         <Summary
           selectedPlan={selectedPlan}
           fromPlanSelector
-          isUpgradeIntent={isUpgradeIntent}
           channelsCount={channelsCount}
           increaseCounter={() => increaseCounter()}
           decreaseCounter={() => decreaseCounter()}

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
@@ -8,9 +8,7 @@ const useInterval = (planOptions, isUpgradeIntent) => {
     isUpgradeIntent
   );
 
-  const initiallyMonthly = isUpgradeIntent
-    ? false
-    : defaultSelectedPlan.planInterval === 'month';
+  const initiallyMonthly = defaultSelectedPlan.planInterval === 'month';
 
   const [monthlyBilling, setBillingInterval] = useState(initiallyMonthly);
 

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.js
@@ -2,11 +2,8 @@ import { useState } from 'react';
 
 import { getDefaultSelectedPlan } from '../../../utils';
 
-const useInterval = (planOptions, isUpgradeIntent) => {
-  const defaultSelectedPlan = getDefaultSelectedPlan(
-    planOptions,
-    isUpgradeIntent
-  );
+const useInterval = (planOptions) => {
+  const defaultSelectedPlan = getDefaultSelectedPlan(planOptions);
 
   const initiallyMonthly = defaultSelectedPlan.planInterval === 'month';
 

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useInterval.test.jsx
@@ -1,41 +1,85 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import useInterval from './useInterval';
 
+const freePlans = [
+  { planId: 'free', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'free', planInterval: 'year', isCurrentPlan: false },
+];
+const essentialsPlans = [
+  {
+    planId: 'essentials',
+    planInterval: 'month',
+    isCurrentPlan: false,
+  },
+  {
+    planId: 'essentials',
+    planInterval: 'year',
+    isCurrentPlan: false,
+  },
+];
+const teamPlans = [
+  { planId: 'team', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+];
+const agencyPlans = [
+  { planId: 'agency', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'agency', planInterval: 'year', isCurrentPlan: false },
+];
+
 describe('useInterval', () => {
   it("should set the current plan's interval as the initial interval", () => {
     const planOptions = [
-      { planId: 'free', planInterval: 'month', isCurrentPlan: true },
-      { planId: 'team', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+      ...freePlans,
+      {
+        planId: 'essentials',
+        planInterval: 'month',
+        isCurrentPlan: true,
+      },
+      {
+        planId: 'essentials',
+        planInterval: 'year',
+        isCurrentPlan: false,
+      },
+      ...teamPlans,
+      ...agencyPlans,
     ];
-    const isFreePlan = false;
 
-    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
+    const { result } = renderHook(() => useInterval(planOptions));
 
     expect(result.current.monthlyBilling).toBe(true);
   });
+
   it("should set the initial interval to year if it's a free plan", () => {
     const planOptions = [
-      { planId: 'free', planInterval: 'month', isCurrentPlan: true },
-      { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'team', planInterval: 'month', isCurrentPlan: false },
+      ...freePlans,
+      ...essentialsPlans,
+      ...teamPlans,
+      ...agencyPlans,
     ];
 
-    const isFreePlan = true;
-
-    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
+    const { result } = renderHook(() => useInterval(planOptions));
 
     expect(result.current.monthlyBilling).toBeFalsy();
   });
+
   it('should change the current interval when updated', () => {
     const planOptions = [
-      { planId: 'free', planInterval: 'month', isCurrentPlan: true },
-      { planId: 'team', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+      ...freePlans,
+      {
+        planId: 'essentials',
+        planInterval: 'month',
+        isCurrentPlan: true,
+      },
+      {
+        planId: 'essentials',
+        planInterval: 'year',
+        isCurrentPlan: false,
+      },
+      ...teamPlans,
+      ...agencyPlans,
     ];
-    const isFreePlan = false;
 
-    const { result } = renderHook(() => useInterval(planOptions, isFreePlan));
+    const { result } = renderHook(() => useInterval(planOptions));
     act(() => {
       result.current.setBillingInterval(!result.current.monthlyBilling);
     });

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.js
@@ -3,11 +3,8 @@ import { freePlan } from '../../../../../common/mocks/freePlan';
 
 import { getDefaultSelectedPlan } from '../../../utils';
 
-const useSelectedPlan = (planOptions, isUpgradeIntent) => {
-  const defaultSelectedPlan = getDefaultSelectedPlan(
-    planOptions,
-    isUpgradeIntent
-  );
+const useSelectedPlan = (planOptions) => {
+  const defaultSelectedPlan = getDefaultSelectedPlan(planOptions);
   const [selectedPlan, setSelectedPlan] = useState(defaultSelectedPlan);
 
   const updateSelectedPlan = (planString) => {

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.test.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/hooks/useSelectedPlan.test.jsx
@@ -7,13 +7,9 @@ const planOptions = [
   { planId: 'free', planInterval: 'month' },
 ];
 
-const isUpgradeIntent = false;
-
 describe('useSelectedPlan', () => {
   it('should set the default as the current plan', () => {
-    const { result } = renderHook(() =>
-      useSelectedPlan(planOptions, isUpgradeIntent)
-    );
+    const { result } = renderHook(() => useSelectedPlan(planOptions));
     expect(result.current.selectedPlan.planId).toBe('team');
   });
 
@@ -32,9 +28,7 @@ describe('useSelectedPlan', () => {
   it('should update the selected plan', () => {
     const planString = 'essentials_year';
 
-    const { result } = renderHook(() =>
-      useSelectedPlan(planOptions, isUpgradeIntent)
-    );
+    const { result } = renderHook(() => useSelectedPlan(planOptions));
     act(() => {
       result.current.updateSelectedPlan(planString);
     });
@@ -44,9 +38,7 @@ describe('useSelectedPlan', () => {
   it('should update the selected plan with a new interval', () => {
     const planString = 'free_month';
 
-    const { result } = renderHook(() =>
-      useSelectedPlan(planOptions, isUpgradeIntent)
-    );
+    const { result } = renderHook(() => useSelectedPlan(planOptions));
     act(() => {
       result.current.updateSelectedPlan(planString);
     });

--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/index.jsx
@@ -41,7 +41,6 @@ const PlanSelector = () => {
                 openSuccess={(newData) => {
                   modal.openModal(MODALS.success, newData);
                 }}
-                isUpgradeIntent={modal.data?.isUpgradeIntent}
               />
             );
           }}

--- a/packages/app-shell/src/components/Modal/modals/Summary/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/Summary/index.jsx
@@ -103,7 +103,6 @@ const Summary = ({
   selectedPlan,
   fromPlanSelector,
   subscriptionEndDate,
-  isUpgradeIntent,
   channelsCount,
   increaseCounter,
   decreaseCounter,
@@ -126,10 +125,6 @@ const Summary = ({
       planStatus = `${fromPlanSelector ? 'Changing to' : 'Paying for'} ${
         selectedPlan?.planName
       }`;
-    }
-
-    if (isUpgradeIntent) {
-      planStatus = `Change to ${selectedPlan?.planName}`;
     }
 
     return (
@@ -243,7 +238,6 @@ const Summary = ({
 const SummaryProvider = ({
   selectedPlan,
   fromPlanSelector,
-  isUpgradeIntent,
   channelsCount,
   increaseCounter,
   decreaseCounter,
@@ -264,7 +258,6 @@ const SummaryProvider = ({
             }
             selectedPlan={selectedPlan}
             fromPlanSelector={fromPlanSelector}
-            isUpgradeIntent={isUpgradeIntent}
             channelsCount={channelsCount}
             increaseCounter={() => increaseCounter()}
             decreaseCounter={() => decreaseCounter()}

--- a/packages/app-shell/src/components/Modal/modals/TrialExpired/index.jsx
+++ b/packages/app-shell/src/components/Modal/modals/TrialExpired/index.jsx
@@ -10,14 +10,13 @@ import { useTrackPageViewed } from '../../../../common/hooks/useSegmentTracking'
 import { UserContext } from '../../../../common/context/User';
 import { ModalContext } from '../../../../common/context/Modal';
 import { MODALS } from '../../../../common/hooks/useModal';
-import { setCookie, DATES } from '../../../../common/utils/cookies'
-
+import { setCookie, DATES } from '../../../../common/utils/cookies';
 
 const ScreenContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 800px;
-  height: ${({ planId }) => planId === 'team' ? '446px' : '376px'};
+  height: ${({ planId }) => (planId === 'team' ? '446px' : '376px')};
   box-sizing: border-box;
   background-repeat: no-repeat;
   background-position-x: right;
@@ -72,30 +71,28 @@ const Details = styled.ul`
   }
 `;
 
-export const Modal = ({
-  user,
-  onDismiss,
-  onUpgrade,
-}) => {
-
+export const Modal = ({ user, onDismiss, onUpgrade }) => {
   useEffect(() => {
     useTrackPageViewed({
       payload: {
         name: 'trial',
         title: 'trial expired modal',
       },
-      user
-    })
-  }, [])
+      user,
+    });
+  }, []);
 
-  const imageUrl = 'https://buffer-ui.s3.amazonaws.com/Confirmation+Illustration.png';
+  const imageUrl =
+    'https://buffer-ui.s3.amazonaws.com/Confirmation+Illustration.png';
   const description = `Your trial is over and you are back to free features. Upgrade to get the power restored.`;
-  const planId = user?.currentOrganization?.billing?.subscription?.plan?.id
-  const changePlanOptions = user?.currentOrganization?.billing?.changePlanOptions || []
-  const planDetails = changePlanOptions.find(o => o.planId === planId)?.summary.details
+  const planId = user?.currentOrganization?.billing?.subscription?.plan?.id;
+  const changePlanOptions =
+    user?.currentOrganization?.billing?.changePlanOptions || [];
+  const planDetails = changePlanOptions.find((o) => o.planId === planId)
+    ?.summary.details;
 
   if (!planDetails) {
-    return null
+    return null;
   }
 
   return (
@@ -104,23 +101,17 @@ export const Modal = ({
       <Text type="p">{description}</Text>
       <Text type="p">Your free plan is limited to:</Text>
       <Details>
-        {planDetails.map(detail => (<li>
-          <CheckmarkIcon size="medium" />
-          <Text type="p">{detail}</Text>
-        </li>))}
+        {planDetails.map((detail) => (
+          <li>
+            <CheckmarkIcon size="medium" />
+            <Text type="p">{detail}</Text>
+          </li>
+        ))}
       </Details>
       <ButtonContainer>
-        <Button
-          type="primary"
-          onClick={onUpgrade}
-          label="Upgrade"
-        />
-      <Button
-        type="secondary"
-        onClick={onDismiss}
-        label="No Thanks"
-      />
-    </ButtonContainer>
+        <Button type="primary" onClick={onUpgrade} label="Upgrade" />
+        <Button type="secondary" onClick={onDismiss} label="No Thanks" />
+      </ButtonContainer>
     </ScreenContainer>
   );
 };
@@ -130,7 +121,7 @@ function setTrialDismissedCookies() {
     key: 'trialOverDismissed',
     value: true,
     expires: DATES.inMonthsFromNow(2),
-  })
+  });
 }
 
 const TrialExpired = () => {
@@ -142,27 +133,25 @@ const TrialExpired = () => {
             <Modal
               user={user}
               onDismiss={() => {
-                setTrialDismissedCookies()
+                setTrialDismissedCookies();
                 openModal(null);
               }}
               onUpgrade={() => {
-                setTrialDismissedCookies()
+                setTrialDismissedCookies();
                 openModal(MODALS.planSelector, {
                   cta: 'trialExpiredUpgrade',
                   ctaButton: 'trialExpired',
-                  isUpgradeIntent: true,
-                })
+                });
               }}
               closeModal={() => {
-                openModal(null)
-              }
-              }
+                openModal(null);
+              }}
             />
           )}
         </ModalContext.Consumer>
       )}
     </UserContext.Consumer>
-  )
+  );
 };
 
 Modal.propTypes = {

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -133,16 +133,6 @@ export function getFreePlanChannelInputMessaging() {
   };
 }
 
-export function handleUpgradeIntent(
-  selectedPlanId,
-  monthlyBilling,
-  updateSelectedPlan
-) {
-  if (selectedPlanId === 'free') {
-    updateSelectedPlan(`essentials_${monthlyBilling ? 'month' : 'year'}`);
-  }
-}
-
 // This will return an array of plan that should be displayed to the user
 // in the selection screen inside the plan selector
 export function getAvailablePlansForDisplay(user, planOptions, showAgencyPlan) {

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -71,13 +71,23 @@ export function getPlanByPlanId(planId, planOptions) {
   return planOptions.find((plan) => plan.planId === planId);
 }
 
+export function getPlanByPlanIdAndInterval(planId, interval, planOptions) {
+  return planOptions.find(
+    (plan) => plan.planId === planId && plan.planInterval === interval
+  );
+}
+
 export function getCurrentPlanFromPlanOptions(planOptions) {
   return planOptions.find((plan) => plan.isCurrentPlan);
 }
 
 export function getDefaultSelectedPlan(planOptions) {
   const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
-  const essentialsPlan = getPlanByPlanId('essentials', planOptions);
+  const essentialsPlan = getPlanByPlanIdAndInterval(
+    'essentials',
+    'year',
+    planOptions
+  );
 
   const defaultSelectedPlan =
     !currentPlan || currentPlan.planId === 'free'

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -79,7 +79,10 @@ export function getDefaultSelectedPlan(planOptions) {
   const currentPlan = getCurrentPlanFromPlanOptions(planOptions);
   const essentialsPlan = getPlanByPlanId('essentials', planOptions);
 
-  const defaultSelectedPlan = !currentPlan ? essentialsPlan : currentPlan;
+  const defaultSelectedPlan =
+    !currentPlan || currentPlan.planId === 'free'
+      ? essentialsPlan
+      : currentPlan;
 
   return defaultSelectedPlan;
 }

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -125,14 +125,6 @@ export function getAgencyPlanMinimumChannelInputMessaging() {
   };
 }
 
-export function getFreePlanChannelInputMessaging() {
-  return {
-    messageStatus: 'warning',
-    message:
-      'The Free plan is limited to 3 channels. Additional channels will be locked.',
-  };
-}
-
 // This will return an array of plan that should be displayed to the user
 // in the selection screen inside the plan selector
 export function getAvailablePlansForDisplay(user, planOptions, showAgencyPlan) {

--- a/packages/app-shell/src/components/Modal/utils.js
+++ b/packages/app-shell/src/components/Modal/utils.js
@@ -1,6 +1,11 @@
 import { getCookie } from '../../common/utils/cookies';
 import { getActiveProductFromPath } from '../../common/utils/getProduct';
-import { isFreeUser, userCanStartFreeTrial } from '../../common/utils/user';
+import {
+  isFreeUser,
+  userCanStartFreeTrial,
+  isAgencyUser,
+  isOnAgencyTrial,
+} from '../../common/utils/user';
 import { SUPPORTED_PRODUCTS as CHANNEL_PROMPT_PRODUCTS } from './modals/ChannelConnectionPrompt';
 
 export function isPendoModalVisible() {
@@ -130,11 +135,39 @@ export function getFreePlanChannelInputMessaging() {
 
 export function handleUpgradeIntent(
   selectedPlanId,
-  isUpgradeIntent,
   monthlyBilling,
   updateSelectedPlan
 ) {
-  if (selectedPlanId === 'free' && isUpgradeIntent) {
+  if (selectedPlanId === 'free') {
     updateSelectedPlan(`essentials_${monthlyBilling ? 'month' : 'year'}`);
   }
+}
+
+// This will return an array of plan that should be displayed to the user
+// in the selection screen inside the plan selector
+export function getAvailablePlansForDisplay(user, planOptions, showAgencyPlan) {
+  const isOnFreePlan = isFreeUser(user);
+  const shouldIncludeAgencyPlan =
+    isAgencyUser(user) || isOnAgencyTrial(user) || showAgencyPlan;
+
+  const planOptionsWithoutFreePlans = filterListOfPlans(planOptions, 'free');
+  const planOptionsWithoutAgencyPlans = filterListOfPlans(
+    planOptions,
+    'agency'
+  );
+
+  if (shouldIncludeAgencyPlan) {
+    return planOptionsWithoutFreePlans;
+  }
+
+  if (isOnFreePlan) {
+    const plansWithoutFreeOrAgency = filterListOfPlans(
+      planOptionsWithoutFreePlans,
+      'agency'
+    );
+
+    return plansWithoutFreeOrAgency;
+  }
+
+  return planOptionsWithoutAgencyPlans;
 }

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -14,6 +14,31 @@ import {
   getAvailablePlansForDisplay,
 } from './utils';
 
+const freePlans = [
+  { planId: 'free', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'free', planInterval: 'year', isCurrentPlan: false },
+];
+const essentialsPlans = [
+  {
+    planId: 'essentials',
+    planInterval: 'month',
+    isCurrentPlan: false,
+  },
+  {
+    planId: 'essentials',
+    planInterval: 'year',
+    isCurrentPlan: false,
+  },
+];
+const teamPlans = [
+  { planId: 'team', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+];
+const agencyPlans = [
+  { planId: 'agency', planInterval: 'month', isCurrentPlan: false },
+  { planId: 'agency', planInterval: 'year', isCurrentPlan: false },
+];
+
 const listOfPlanOptions = [
   { planId: 'free', planInterval: 'month', isCurrentPlan: false },
   { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
@@ -21,8 +46,10 @@ const listOfPlanOptions = [
 ];
 
 const listOfPlanOptionsWithNoCurrentPlan = [
-  { planId: 'essentials', planInterval: 'month', isCurrentPlan: false },
-  { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+  ...freePlans,
+  ...essentialsPlans,
+  ...teamPlans,
+  ...agencyPlans,
 ];
 
 const listOfFilteredPlanOptions = [
@@ -205,14 +232,14 @@ describe('Modal - utils', () => {
       });
     });
 
-    it('should set the default selected plan to essentials when isCurrentPlan cannot be found in the list of plans', () => {
+    it('should set the default selected plan to essentials yearly when isCurrentPlan cannot be found in the list of plans', () => {
       const planOptions = [...listOfPlanOptionsWithNoCurrentPlan];
 
       const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
 
       expect(result).toEqual({
         planId: 'essentials',
-        planInterval: 'month',
+        planInterval: 'year',
         isCurrentPlan: false,
       });
     });
@@ -452,31 +479,6 @@ describe('Modal - utils', () => {
   });
 
   describe('getAvailablePlansForDisplay', () => {
-    const freePlans = [
-      { planId: 'free', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'free', planInterval: 'year', isCurrentPlan: false },
-    ];
-    const essentialsPlans = [
-      {
-        planId: 'essentials',
-        planInterval: 'month',
-        isCurrentPlan: false,
-      },
-      {
-        planId: 'essentials',
-        planInterval: 'year',
-        isCurrentPlan: false,
-      },
-    ];
-    const teamPlans = [
-      { planId: 'team', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'team', planInterval: 'year', isCurrentPlan: false },
-    ];
-    const agencyPlans = [
-      { planId: 'agency', planInterval: 'month', isCurrentPlan: false },
-      { planId: 'agency', planInterval: 'year', isCurrentPlan: false },
-    ];
-
     it('should return an array of plans with no Free options when the agency plan should be displayed', () => {
       const user = {
         currentOrganization: {

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -57,8 +57,6 @@ const listOfFilteredPlanOptions = [
   { planId: 'team', planInterval: 'year', isCurrentPlan: true },
 ];
 
-const isUpgradeIntent = false;
-
 describe('Modal - utils', () => {
   describe('isPendoModalVisible', () => {
     it('should return true if there is a pendo modal visible', () => {
@@ -223,7 +221,7 @@ describe('Modal - utils', () => {
         ...listOfFilteredPlanOptions,
       ];
 
-      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
+      const result = getDefaultSelectedPlan(planOptions);
 
       expect(result).toEqual({
         planId: 'team',
@@ -235,7 +233,7 @@ describe('Modal - utils', () => {
     it('should set the default selected plan to essentials yearly when isCurrentPlan cannot be found in the list of plans', () => {
       const planOptions = [...listOfPlanOptionsWithNoCurrentPlan];
 
-      const result = getDefaultSelectedPlan(planOptions, isUpgradeIntent);
+      const result = getDefaultSelectedPlan(planOptions);
 
       expect(result).toEqual({
         planId: 'essentials',

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -451,7 +451,7 @@ describe('Modal - utils', () => {
     });
   });
 
-  describe.only('getAvailablePlansForDisplay', () => {
+  describe('getAvailablePlansForDisplay', () => {
     const freePlans = [
       { planId: 'free', planInterval: 'month', isCurrentPlan: false },
       { planId: 'free', planInterval: 'year', isCurrentPlan: false },
@@ -478,6 +478,21 @@ describe('Modal - utils', () => {
     ];
 
     it('should return an array of plans with no Free options when the agency plan should be displayed', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: false,
+              },
+              plan: {
+                id: 'free',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -485,15 +500,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = false;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = true;
+      const showAgencyPlan = true;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining(freePlans));
       expect(result).toEqual([
@@ -504,6 +516,21 @@ describe('Modal - utils', () => {
     });
 
     it('should return an array of plans with no Free options when the agency plan should be displayed and the user is on a free plan', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: false,
+              },
+              plan: {
+                id: 'free',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -511,15 +538,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = true;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = true;
+      const showAgencyPlan = true;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining(freePlans));
       expect(result).toEqual([
@@ -529,8 +553,22 @@ describe('Modal - utils', () => {
       ]);
     });
 
-    // TODO fix this test
     it('should return an array of plans with no Free options when the user is on an Agency trial', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: true,
+              },
+              plan: {
+                id: 'agency',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -538,15 +576,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = true;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = true;
+      const showAgencyPlan = true;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining(freePlans));
       expect(result).toEqual([
@@ -556,8 +591,22 @@ describe('Modal - utils', () => {
       ]);
     });
 
-    // TODO fix this test
     it('should return an array of plans with no Free options when the user is on an Agency plan', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: false,
+              },
+              plan: {
+                id: 'agency',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -565,15 +614,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = true;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = true;
+      const showAgencyPlan = true;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining(freePlans));
       expect(result).toEqual([
@@ -583,8 +629,9 @@ describe('Modal - utils', () => {
       ]);
     });
 
-    // TODO fix this test
     it('should return an array of plans with no Free options when the provided with showAgencyPlan set to true', () => {
+      const user = {};
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -592,15 +639,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = true;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = true;
+      const showAgencyPlan = true;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining(freePlans));
       expect(result).toEqual([
@@ -610,8 +654,22 @@ describe('Modal - utils', () => {
       ]);
     });
 
-    // TODO: fix this test - add correct test values
     it('should return an array of plans with no Agency or Free plan options when the user is on a free plan', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: false,
+              },
+              plan: {
+                id: 'free',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -619,21 +677,35 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = true;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = false;
+      const showAgencyPlan = false;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
-      expect(result).toEqual(expect.not.arrayContaining([...agencyPlans]));
-      expect(result).toEqual([...freePlans, ...essentialsPlans, ...teamPlans]);
+      expect(result).toEqual(
+        expect.not.arrayContaining([...freePlans, ...agencyPlans])
+      );
+      expect(result).toEqual([...essentialsPlans, ...teamPlans]);
     });
 
     it('should return an array of plans with no Agency options when Agency should not be included ', () => {
+      const user = {
+        currentOrganization: {
+          billing: {
+            subscription: {
+              trial: {
+                isActive: false,
+              },
+              plan: {
+                id: 'essentials',
+              },
+            },
+          },
+        },
+      };
+
       const listOfPlanOptions = [
         ...freePlans,
         ...essentialsPlans,
@@ -641,15 +713,12 @@ describe('Modal - utils', () => {
         ...agencyPlans,
       ];
 
-      const isOnFreePlan = false;
-      const isUpgradeIntent = false;
-      const shouldIncludeAgencyPlan = false;
+      const showAgencyPlan = false;
 
       const result = getAvailablePlansForDisplay(
+        user,
         listOfPlanOptions,
-        isOnFreePlan,
-        isUpgradeIntent,
-        shouldIncludeAgencyPlan
+        showAgencyPlan
       );
       expect(result).toEqual(expect.not.arrayContaining([...agencyPlans]));
       expect(result).toEqual([...freePlans, ...essentialsPlans, ...teamPlans]);

--- a/packages/app-shell/src/components/Modal/utils.test.jsx
+++ b/packages/app-shell/src/components/Modal/utils.test.jsx
@@ -11,6 +11,7 @@ import {
   getDefaultSelectedPlan,
   calculateTotalSlotsPrice,
   getPlanByPlanId,
+  getAvailablePlansForDisplay,
 } from './utils';
 
 const listOfPlanOptions = [
@@ -447,6 +448,211 @@ describe('Modal - utils', () => {
       });
       const result = shouldShowPaywallModal(noChannelsUser);
       expect(result).toBeFalsy();
+    });
+  });
+
+  describe.only('getAvailablePlansForDisplay', () => {
+    const freePlans = [
+      { planId: 'free', planInterval: 'month', isCurrentPlan: false },
+      { planId: 'free', planInterval: 'year', isCurrentPlan: false },
+    ];
+    const essentialsPlans = [
+      {
+        planId: 'essentials',
+        planInterval: 'month',
+        isCurrentPlan: false,
+      },
+      {
+        planId: 'essentials',
+        planInterval: 'year',
+        isCurrentPlan: false,
+      },
+    ];
+    const teamPlans = [
+      { planId: 'team', planInterval: 'month', isCurrentPlan: false },
+      { planId: 'team', planInterval: 'year', isCurrentPlan: false },
+    ];
+    const agencyPlans = [
+      { planId: 'agency', planInterval: 'month', isCurrentPlan: false },
+      { planId: 'agency', planInterval: 'year', isCurrentPlan: false },
+    ];
+
+    it('should return an array of plans with no Free options when the agency plan should be displayed', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = false;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = true;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining(freePlans));
+      expect(result).toEqual([
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ]);
+    });
+
+    it('should return an array of plans with no Free options when the agency plan should be displayed and the user is on a free plan', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = true;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = true;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining(freePlans));
+      expect(result).toEqual([
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ]);
+    });
+
+    // TODO fix this test
+    it('should return an array of plans with no Free options when the user is on an Agency trial', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = true;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = true;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining(freePlans));
+      expect(result).toEqual([
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ]);
+    });
+
+    // TODO fix this test
+    it('should return an array of plans with no Free options when the user is on an Agency plan', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = true;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = true;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining(freePlans));
+      expect(result).toEqual([
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ]);
+    });
+
+    // TODO fix this test
+    it('should return an array of plans with no Free options when the provided with showAgencyPlan set to true', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = true;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = true;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining(freePlans));
+      expect(result).toEqual([
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ]);
+    });
+
+    // TODO: fix this test - add correct test values
+    it('should return an array of plans with no Agency or Free plan options when the user is on a free plan', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = true;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = false;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining([...agencyPlans]));
+      expect(result).toEqual([...freePlans, ...essentialsPlans, ...teamPlans]);
+    });
+
+    it('should return an array of plans with no Agency options when Agency should not be included ', () => {
+      const listOfPlanOptions = [
+        ...freePlans,
+        ...essentialsPlans,
+        ...teamPlans,
+        ...agencyPlans,
+      ];
+
+      const isOnFreePlan = false;
+      const isUpgradeIntent = false;
+      const shouldIncludeAgencyPlan = false;
+
+      const result = getAvailablePlansForDisplay(
+        listOfPlanOptions,
+        isOnFreePlan,
+        isUpgradeIntent,
+        shouldIncludeAgencyPlan
+      );
+      expect(result).toEqual(expect.not.arrayContaining([...agencyPlans]));
+      expect(result).toEqual([...freePlans, ...essentialsPlans, ...teamPlans]);
     });
   });
 });

--- a/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
@@ -28,7 +28,7 @@ const UpgradeCTA = () => {
         const { currentOrganization } = user;
         const { isOneBufferOrganization } = currentOrganization;
         const isFree = isFreePlan(user);
-        const [hostname, envModifier] = window.location.hostname.match(
+        const [, envModifier] = window.location.hostname.match(
           /\w+\.(\w+\.)buffer\.com/
         ) || [null, null];
 

--- a/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
+++ b/packages/app-shell/src/components/NavBar/components/UpgradeCTA.jsx
@@ -9,7 +9,7 @@ import PeopleIcon from '@bufferapp/ui/Icon/Icons/People';
 import { UserContext } from '../../../common/context/User';
 import { ModalContext } from '../../../common/context/Modal';
 import { MODALS } from '../../../common/hooks/useModal';
-import { isFreePlan } from '../../../common/hooks/utils/segmentTraitGetters'
+import { isFreePlan } from '../../../common/hooks/utils/segmentTraitGetters';
 
 const Cta = styled.div`
   display: inline-flex;
@@ -28,8 +28,9 @@ const UpgradeCTA = () => {
         const { currentOrganization } = user;
         const { isOneBufferOrganization } = currentOrganization;
         const isFree = isFreePlan(user);
-        const [hostname, envModifier] = window.location.hostname.match(/\w+\.(\w+\.)buffer\.com/) || [null, null]
-
+        const [hostname, envModifier] = window.location.hostname.match(
+          /\w+\.(\w+\.)buffer\.com/
+        ) || [null, null];
 
         if (currentOrganization.shouldDisplayInviteCTA) {
           return (
@@ -37,13 +38,17 @@ const UpgradeCTA = () => {
               <Button
                 type="text"
                 onClick={() => {
-                  window.location = `https://${envModifier ? envModifier : ''}buffer.com/manage/${currentOrganization.id}/team-members/invite`;
+                  window.location = `https://${
+                    envModifier ? envModifier : ''
+                  }buffer.com/manage/${
+                    currentOrganization.id
+                  }/team-members/invite`;
                 }}
                 icon={<PeopleIcon />}
                 label="Invite Your Team"
               />
             </Cta>
-          )
+          );
         }
 
         if (currentOrganization.billing) {
@@ -59,24 +64,25 @@ const UpgradeCTA = () => {
                         onClick={() => {
                           if (isOneBufferOrganization) {
                             if (canStartTrial) {
-                             openModal(MODALS.startTrial, {
+                              openModal(MODALS.startTrial, {
                                 cta: 'startTrialNavigatorBar',
                                 ctaButton: 'startTrial',
-                              })
+                              });
                             } else {
                               openModal(MODALS.planSelector, {
                                 cta: 'upgradePlanNavigatorBar',
                                 ctaButton: 'upgradePlan',
-                                isUpgradeIntent: true,
                               });
                             }
                           } else {
-                            window.location = `https://publish.${envModifier ? envModifier : ''}buffer.com/plans`;
+                            window.location = `https://publish.${
+                              envModifier ? envModifier : ''
+                            }buffer.com/plans`;
                           }
                         }}
                         icon={<FlashIcon />}
                         label={
-                          (canStartTrial && isOneBufferOrganization)
+                          canStartTrial && isOneBufferOrganization
                             ? 'Start a 14-day free trial'
                             : 'Upgrade'
                         }

--- a/packages/app-shell/src/components/NavBar/index.jsx
+++ b/packages/app-shell/src/components/NavBar/index.jsx
@@ -352,9 +352,7 @@ const NavBar = React.memo((props) => {
                   icon: <PersonIcon color={gray} />,
                   hasDivider: organizations.length > 1,
                   onItemClick: () => {
-                    window.location.assign(
-                      getAccountUrl()
-                    );
+                    window.location.assign(getAccountUrl());
                   },
                 },
                 ...menuItems,
@@ -393,7 +391,6 @@ const NavBar = React.memo((props) => {
                         openModal(MODALS.planSelector, {
                           cta: 'ugradePlan',
                           ctaButton: 'ugradePlan',
-                          isUpgradeIntent: true,
                         });
                       },
                     }
@@ -409,7 +406,6 @@ const NavBar = React.memo((props) => {
                         openModal(MODALS.startTrial, {
                           cta: 'startFreeTrial',
                           ctaButton: 'startFreeTrial',
-                          isUpgradeIntent: true,
                         });
                       },
                     }

--- a/packages/app-shell/src/exports/Navigator/index.jsx
+++ b/packages/app-shell/src/exports/Navigator/index.jsx
@@ -114,7 +114,6 @@ export const Navigator = React.memo(({ apolloClient, channels }) => {
               action: () =>
                 modal.openModal(MODALS.planSelector, {
                   cta: 'addPaymentDetailsBanner',
-                  isUpgradeIntent: true,
                 }),
             }}
           />

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -20,7 +20,7 @@ const Portal = styled.div`
   border: 6px solid #decd9c;
 
   &:before {
-    content: "#components_container";
+    content: '#components_container';
     font-size: 64px;
     font-weight: bold;
     color: #decd9c;
@@ -40,6 +40,7 @@ const ModalTesting = () => {
     <Wrapper>
       <h3>Render Plan Selector</h3>
       <button
+        id="render_plan_selector"
         onClick={() => {
           const { MODALS, actions } = window?.appshell || {};
           actions.openModal(MODALS.planSelector, {
@@ -88,9 +89,9 @@ const ModalTesting = () => {
             containerId: 'components_container',
             options: {
               cta: 'orchestrator_trial',
-              ctaButton: 'orchestrator_button'
-            }
-          })
+              ctaButton: 'orchestrator_button',
+            },
+          });
         }}
       >
         Render Start Trial Button

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -46,7 +46,6 @@ const ModalTesting = () => {
           actions.openModal(MODALS.planSelector, {
             cta: 'renderModal',
             ctaButton: 'renderModal',
-            isUpgradeIntent: false,
           });
         }}
       >
@@ -60,7 +59,6 @@ const ModalTesting = () => {
           actions.openModal(MODALS.paidMigration, {
             cta: 'renderModal',
             ctaButton: 'renderModal',
-            isUpgradeIntent: false,
           });
         }}
       >
@@ -74,7 +72,6 @@ const ModalTesting = () => {
           actions.openModal(MODALS.quantityUpdate, {
             cta: 'renderModal',
             ctaButton: 'renderModal',
-            isUpgradeIntent: false,
           });
         }}
       >


### PR DESCRIPTION
👀 Because making changes to this logic has been known to cause unforeseen issues for customer would I be able to get some reviews on this PR 😊 

Jira: https://buffer.atlassian.net/browse/GROW-434
Slack threads with more context: https://buffer.slack.com/archives/C0DLE125Q/p1647986280463599

The plan selctor now follows these rules:

If the user is on anything but an agency plan or trial, we show Free | Essentials | Essentials + Team
This should apply to the Plan Selector no matter where it opens from (test with upsell banner, account/billing, upgrade paths, etc.)
The only time the Plan Selector should show the Agency state (Essentials | Essentials + Team | Agency) is if the user is:
1) On an Agency trial
2) On an Agency plan
3) Clicked the CTA in the bottom of the Plan Selector to explicitly view it (“Need more than 10 channels? Try our Agency Plan”)
When a user is on the Free plan only Essentials and Team will be displayed and Essentials will be selected as default


This also contains some new Cypress tests to cover these scenarios



**New plan selector layouts:**
When the user is on an agency plan or trial: 
![Screen Shot 2022-03-28 at 3 05 52 pm](https://user-images.githubusercontent.com/7763710/160329896-e969e8c4-fb9d-4491-a07e-cbd015d7dc30.png)

When the user is on the free plan and has clicked the Agency CTA in footer:
![Screen Shot 2022-03-28 at 3 05 36 pm](https://user-images.githubusercontent.com/7763710/160329905-68c9d289-e50a-45a0-87a3-55ee77ffe1bb.png)

When the user is on a Free plan:
![Screen Shot 2022-03-28 at 3 05 22 pm](https://user-images.githubusercontent.com/7763710/160329907-a96d536a-c2ac-41c2-9faa-ab9c551cd109.png)

When the user is on the Team plan:
![Screen Shot 2022-03-28 at 3 04 44 pm](https://user-images.githubusercontent.com/7763710/160329909-9fdbe25c-a5bb-48e9-ae67-8adb62bfa232.png)
