### PR TITLE
increase width for saving copy to be on one line

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/PlanSelector/style.js
+++ b/packages/app-shell/src/components/Modal/modals/PlanSelector/style.js
@@ -89,7 +89,7 @@ export const AbsoluteSavings = styled.span`
   letter-spacing: 0px;
   color: ${blue};
   text-align: right;
-  width: 110px;
+  width: 120px;
 `;
 
 export const ButtonContainer = styled.div`


### PR DESCRIPTION
I noticed that for Agency plans, the saving copy is on 2 lines instead of 1 for the rest.

Before
<img width="279" alt="Screenshot 2022-03-28 at 16 50 19" src="https://user-images.githubusercontent.com/1514227/160373514-da2322f0-ff40-4773-a30a-458e494dbee1.png">

After
<img width="315" alt="Screenshot 2022-03-28 at 16 49 57" src="https://user-images.githubusercontent.com/1514227/160373530-79a6be6d-a5de-4142-a6f6-72247522a13a.png">

