### PR TITLE
[GROW-452] add currently paying amount to quantity modal

### DIFF
--- a/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
+++ b/packages/app-shell/src/components/Modal/modals/QuantityUpdate/components/CardBody.jsx
@@ -49,6 +49,14 @@ const CardBody = ({
     channelFee
   );
 
+  const currentPrice = calculateTotalSlotsPrice(
+    planId,
+    quantity,
+    pricePerQuantity,
+    minimumQuantity,
+    channelFee
+  );
+
   const {
     updateSubscriptionQuantity,
     data: updateQuantityData,
@@ -118,6 +126,7 @@ const CardBody = ({
             <Summary>
               {hasCounterChanged ? (
                 <>
+                  <Text type="p">Currently paying: ${currentPrice}</Text>
                   <Text type="p">
                     New cost: <strong>${newPrice}</strong>
                   </Text>


### PR DESCRIPTION
Before
<img width="521" alt="Screenshot 2022-03-31 at 09 39 24" src="https://user-images.githubusercontent.com/1514227/160965241-dc9a8176-cff2-4eb9-8c7c-6de1a0b16e7e.png">

After
<img width="527" alt="Screenshot 2022-03-31 at 09 36 27" src="https://user-images.githubusercontent.com/1514227/160965064-7b531c13-1368-4365-9112-db63e9635426.png">

